### PR TITLE
feat: overhaul menu bot with planner and shopping tools

### DIFF
--- a/database.py
+++ b/database.py
@@ -1,21 +1,1020 @@
+import asyncio
+import json
 import sqlite3
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple
 
-def get_db_connection():
-    # Подключение к базе данных
-    conn = sqlite3.connect('menu.db')
+DB_PATH = Path(__file__).with_name("menu.db")
+
+
+def get_db_connection() -> sqlite3.Connection:
+    conn = sqlite3.connect(DB_PATH)
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA foreign_keys = ON")
     return conn
 
-def create_tables():
-    # Создание таблиц в базе данных
+
+def _ensure_column(conn: sqlite3.Connection, table: str, column: str, ddl: str) -> None:
+    existing = {row[1] for row in conn.execute(f"PRAGMA table_info({table})").fetchall()}
+    if column not in existing:
+        conn.execute(f"ALTER TABLE {table} ADD COLUMN {column} {ddl}")
+
+
+def create_tables() -> None:
     conn = get_db_connection()
     cursor = conn.cursor()
-    cursor.execute('''
-    CREATE TABLE IF NOT EXISTS dishes (
-        id INTEGER PRIMARY KEY AUTOINCREMENT,
-        name TEXT NOT NULL,
-        ingredients TEXT,
-        recipe TEXT
+
+    cursor.execute(
+        """
+        CREATE TABLE IF NOT EXISTS dishes (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            name TEXT NOT NULL,
+            ingredients TEXT,
+            recipe TEXT
+        )
+        """
     )
-    ''')
+
+    _ensure_column(conn, "dishes", "description", "TEXT")
+    _ensure_column(conn, "dishes", "instructions", "TEXT")
+    _ensure_column(conn, "dishes", "category", "TEXT")
+    _ensure_column(conn, "dishes", "cuisine", "TEXT")
+    _ensure_column(conn, "dishes", "servings", "INTEGER DEFAULT 1")
+    _ensure_column(conn, "dishes", "prep_time", "INTEGER DEFAULT 0")
+    _ensure_column(conn, "dishes", "cook_time", "INTEGER DEFAULT 0")
+    _ensure_column(conn, "dishes", "difficulty", "TEXT")
+    _ensure_column(conn, "dishes", "is_favorite", "INTEGER DEFAULT 0")
+    _ensure_column(conn, "dishes", "created_at", "TEXT DEFAULT CURRENT_TIMESTAMP")
+    _ensure_column(conn, "dishes", "updated_at", "TEXT DEFAULT CURRENT_TIMESTAMP")
+    _ensure_column(conn, "dishes", "source", "TEXT")
+    _ensure_column(conn, "dishes", "notes", "TEXT")
+
+    cursor.execute(
+        """
+        CREATE UNIQUE INDEX IF NOT EXISTS idx_dishes_name ON dishes(LOWER(name))
+        """
+    )
+
+    cursor.execute(
+        """
+        CREATE TABLE IF NOT EXISTS dish_ingredients (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            dish_id INTEGER NOT NULL,
+            name TEXT NOT NULL,
+            quantity REAL,
+            unit TEXT,
+            calories REAL,
+            protein REAL,
+            fat REAL,
+            carbs REAL,
+            UNIQUE(dish_id, name, unit),
+            FOREIGN KEY(dish_id) REFERENCES dishes(id) ON DELETE CASCADE
+        )
+        """
+    )
+
+    cursor.execute(
+        """
+        CREATE TABLE IF NOT EXISTS dish_tags (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            dish_id INTEGER NOT NULL,
+            tag TEXT NOT NULL,
+            UNIQUE(dish_id, tag),
+            FOREIGN KEY(dish_id) REFERENCES dishes(id) ON DELETE CASCADE
+        )
+        """
+    )
+    cursor.execute(
+        """
+        CREATE TABLE IF NOT EXISTS meal_plans (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            user_id TEXT NOT NULL,
+            chat_id INTEGER NOT NULL,
+            dish_id INTEGER NOT NULL,
+            plan_date TEXT NOT NULL,
+            meal_type TEXT NOT NULL,
+            servings REAL DEFAULT 1,
+            notes TEXT,
+            created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+            FOREIGN KEY(dish_id) REFERENCES dishes(id) ON DELETE CASCADE
+        )
+        """
+    )
+
+    cursor.execute(
+        """
+        CREATE TABLE IF NOT EXISTS reminders (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            user_id TEXT NOT NULL,
+            chat_id INTEGER NOT NULL,
+            dish_id INTEGER,
+            plan_id INTEGER,
+            remind_at TEXT NOT NULL,
+            message TEXT NOT NULL,
+            job_name TEXT NOT NULL,
+            created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+            FOREIGN KEY(dish_id) REFERENCES dishes(id) ON DELETE SET NULL,
+            FOREIGN KEY(plan_id) REFERENCES meal_plans(id) ON DELETE CASCADE
+        )
+        """
+    )
+
+    cursor.execute(
+        """
+        CREATE TABLE IF NOT EXISTS shopping_items (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            user_id TEXT NOT NULL,
+            name TEXT NOT NULL,
+            quantity REAL,
+            unit TEXT,
+            added_at TEXT DEFAULT CURRENT_TIMESTAMP
+        )
+        """
+    )
+
+    cursor.execute(
+        """
+        CREATE TABLE IF NOT EXISTS user_actions (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            user_id TEXT NOT NULL,
+            dish_id INTEGER,
+            action TEXT NOT NULL,
+            payload TEXT,
+            created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+            FOREIGN KEY(dish_id) REFERENCES dishes(id) ON DELETE SET NULL
+        )
+        """
+    )
+
+    cursor.execute(
+        """
+        CREATE INDEX IF NOT EXISTS idx_meal_plans_user_date ON meal_plans(user_id, plan_date)
+        """
+    )
+    cursor.execute(
+        """
+        CREATE INDEX IF NOT EXISTS idx_reminders_user_time ON reminders(user_id, remind_at)
+        """
+    )
+
+    cursor.execute(
+        """
+        UPDATE dishes SET instructions = recipe WHERE instructions IS NULL AND recipe IS NOT NULL
+        """
+    )
+
     conn.commit()
     conn.close()
+
+
+async def _run_in_thread(func, *args, **kwargs):
+    return await asyncio.to_thread(func, *args, **kwargs)
+
+
+def _row_to_dict(row: sqlite3.Row) -> Dict[str, Any]:
+    return {key: row[key] for key in row.keys()}
+
+
+async def list_dishes(order_by: str = "name") -> List[Dict[str, Any]]:
+    def _list() -> List[Dict[str, Any]]:
+        conn = get_db_connection()
+        cursor = conn.cursor()
+        cursor.execute(f"SELECT * FROM dishes ORDER BY {order_by} COLLATE NOCASE")
+        rows = cursor.fetchall()
+        conn.close()
+        dishes: List[Dict[str, Any]] = []
+        for row in rows:
+            data = _row_to_dict(row)
+            data["tags"] = [tag_row[0] for tag_row in cursor.execute("SELECT tag FROM dish_tags WHERE dish_id = ? ORDER BY tag", (row["id"],)).fetchall()]
+            data["ingredients_list"] = [
+                _row_to_dict(ing)
+                for ing in cursor.execute(
+                    "SELECT name, quantity, unit, calories, protein, fat, carbs FROM dish_ingredients WHERE dish_id = ? ORDER BY name",
+                    (row["id"],),
+                ).fetchall()
+            ]
+            dishes.append(data)
+        return dishes
+
+    return await _run_in_thread(_list)
+
+
+async def get_dish_by_id(dish_id: int) -> Optional[Dict[str, Any]]:
+    def _get() -> Optional[Dict[str, Any]]:
+        conn = get_db_connection()
+        cursor = conn.cursor()
+        cursor.execute("SELECT * FROM dishes WHERE id = ?", (dish_id,))
+        row = cursor.fetchone()
+        if not row:
+            conn.close()
+            return None
+        data = _row_to_dict(row)
+        data["tags"] = [tag_row[0] for tag_row in cursor.execute("SELECT tag FROM dish_tags WHERE dish_id = ? ORDER BY tag", (dish_id,)).fetchall()]
+        data["ingredients_list"] = [
+            _row_to_dict(ing)
+            for ing in cursor.execute(
+                "SELECT name, quantity, unit, calories, protein, fat, carbs FROM dish_ingredients WHERE dish_id = ? ORDER BY name",
+                (dish_id,),
+            ).fetchall()
+        ]
+        conn.close()
+        return data
+
+    return await _run_in_thread(_get)
+
+
+async def get_dish_by_name(name: str) -> Optional[Dict[str, Any]]:
+    def _get() -> Optional[Dict[str, Any]]:
+        conn = get_db_connection()
+        cursor = conn.cursor()
+        cursor.execute("SELECT id FROM dishes WHERE LOWER(name) = LOWER(?)", (name.strip(),))
+        row = cursor.fetchone()
+        conn.close()
+        if not row:
+            return None
+        return row["id"]
+
+    dish_id = await _run_in_thread(_get)
+    if dish_id is None:
+        return None
+    return await get_dish_by_id(dish_id)
+
+async def search_dish_names(query: str, limit: int = 5) -> List[Dict[str, Any]]:
+    pattern = f"%{query.strip().lower()}%"
+
+    def _search() -> List[Dict[str, Any]]:
+        conn = get_db_connection()
+        cursor = conn.cursor()
+        cursor.execute(
+            "SELECT id, name FROM dishes WHERE LOWER(name) LIKE ? ORDER BY name LIMIT ?",
+            (pattern, limit),
+        )
+        rows = cursor.fetchall()
+        conn.close()
+        return [dict(row) for row in rows]
+
+    return await _run_in_thread(_search)
+
+
+async def add_dish(
+    dish_data: Dict[str, Any],
+    ingredients: Sequence[Dict[str, Any]],
+    tags: Sequence[str],
+) -> int:
+    name = dish_data.get("name", "").strip()
+    if not name:
+        raise ValueError("Название блюда не может быть пустым")
+
+    def _insert() -> int:
+        conn = get_db_connection()
+        cursor = conn.cursor()
+        cursor.execute("SELECT id FROM dishes WHERE LOWER(name) = LOWER(?)", (name,))
+        if cursor.fetchone():
+            conn.close()
+            raise ValueError("Блюдо с таким названием уже существует")
+
+        now = datetime.utcnow().isoformat()
+        servings = dish_data.get("servings") or 1
+        aggregated_ingredients = "; ".join(
+            f"{ing.get('name')} {ing.get('quantity', '')}{ing.get('unit', '')}".strip()
+            for ing in ingredients
+            if ing.get("name")
+        )
+        instructions = dish_data.get("instructions") or dish_data.get("recipe") or ""
+        cursor.execute(
+            """
+            INSERT INTO dishes (
+                name, description, ingredients, recipe, instructions, category, cuisine,
+                servings, prep_time, cook_time, difficulty, is_favorite, source, notes,
+                created_at, updated_at
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                name,
+                dish_data.get("description"),
+                aggregated_ingredients,
+                instructions,
+                instructions,
+                dish_data.get("category"),
+                dish_data.get("cuisine"),
+                servings,
+                dish_data.get("prep_time") or 0,
+                dish_data.get("cook_time") or 0,
+                dish_data.get("difficulty"),
+                1 if dish_data.get("is_favorite") else 0,
+                dish_data.get("source"),
+                dish_data.get("notes"),
+                now,
+                now,
+            ),
+        )
+        dish_id = cursor.lastrowid
+
+        for ingredient in ingredients:
+            if not ingredient.get("name"):
+                continue
+            cursor.execute(
+                """
+                INSERT INTO dish_ingredients (
+                    dish_id, name, quantity, unit, calories, protein, fat, carbs
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    dish_id,
+                    ingredient.get("name"),
+                    ingredient.get("quantity"),
+                    ingredient.get("unit"),
+                    ingredient.get("calories"),
+                    ingredient.get("protein"),
+                    ingredient.get("fat"),
+                    ingredient.get("carbs"),
+                ),
+            )
+
+        for tag in tags:
+            clean_tag = tag.strip().lower()
+            if clean_tag:
+                cursor.execute(
+                    "INSERT OR IGNORE INTO dish_tags (dish_id, tag) VALUES (?, ?)",
+                    (dish_id, clean_tag),
+                )
+
+        conn.commit()
+        conn.close()
+        return dish_id
+
+    return await _run_in_thread(_insert)
+
+
+async def update_dish(dish_id: int, updates: Dict[str, Any]) -> bool:
+    if not updates:
+        return False
+
+    valid_fields = {
+        "name",
+        "description",
+        "ingredients",
+        "recipe",
+        "instructions",
+        "category",
+        "cuisine",
+        "servings",
+        "prep_time",
+        "cook_time",
+        "difficulty",
+        "is_favorite",
+        "source",
+        "notes",
+    }
+
+    sets: List[str] = []
+    values: List[Any] = []
+    for field, value in updates.items():
+        if field not in valid_fields:
+            continue
+        sets.append(f"{field} = ?")
+        values.append(value)
+
+    if not sets:
+        return False
+
+    values.append(datetime.utcnow().isoformat())
+    values.append(dish_id)
+
+    def _update() -> bool:
+        conn = get_db_connection()
+        cursor = conn.cursor()
+        cursor.execute(
+            f"UPDATE dishes SET {', '.join(sets)}, updated_at = ? WHERE id = ?",
+            values,
+        )
+        affected = cursor.rowcount > 0
+        conn.commit()
+        conn.close()
+        return affected
+
+    return await _run_in_thread(_update)
+
+
+async def delete_dish(dish_id: int) -> bool:
+    def _delete() -> bool:
+        conn = get_db_connection()
+        cursor = conn.cursor()
+        cursor.execute("DELETE FROM dishes WHERE id = ?", (dish_id,))
+        affected = cursor.rowcount > 0
+        conn.commit()
+        conn.close()
+        return affected
+
+    return await _run_in_thread(_delete)
+
+
+async def replace_dish_details(
+    dish_id: int,
+    ingredients: Sequence[Dict[str, Any]],
+    instructions: Optional[str] = None,
+    tags: Optional[Sequence[str]] = None,
+    description: Optional[str] = None,
+) -> bool:
+    def _replace() -> bool:
+        conn = get_db_connection()
+        cursor = conn.cursor()
+        cursor.execute("SELECT id FROM dishes WHERE id = ?", (dish_id,))
+        if not cursor.fetchone():
+            conn.close()
+            return False
+
+        cursor.execute("DELETE FROM dish_ingredients WHERE dish_id = ?", (dish_id,))
+        aggregated_ingredients = []
+        for ingredient in ingredients:
+            if not ingredient.get("name"):
+                continue
+            cursor.execute(
+                """
+                INSERT INTO dish_ingredients (
+                    dish_id, name, quantity, unit, calories, protein, fat, carbs
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    dish_id,
+                    ingredient.get("name"),
+                    ingredient.get("quantity"),
+                    ingredient.get("unit"),
+                    ingredient.get("calories"),
+                    ingredient.get("protein"),
+                    ingredient.get("fat"),
+                    ingredient.get("carbs"),
+                ),
+            )
+            aggregated_ingredients.append(
+                f"{ingredient.get('name')} {ingredient.get('quantity', '')}{ingredient.get('unit', '')}".strip()
+            )
+
+        if tags is not None:
+            cursor.execute("DELETE FROM dish_tags WHERE dish_id = ?", (dish_id,))
+            for tag in tags:
+                clean_tag = tag.strip().lower()
+                if clean_tag:
+                    cursor.execute(
+                        "INSERT OR IGNORE INTO dish_tags (dish_id, tag) VALUES (?, ?)",
+                        (dish_id, clean_tag),
+                    )
+
+        updates = {"ingredients": "; ".join(aggregated_ingredients)}
+        if instructions is not None:
+            updates["recipe"] = instructions
+            updates["instructions"] = instructions
+        if description is not None:
+            updates["description"] = description
+
+        set_parts = [f"{key} = ?" for key in updates]
+        values = list(updates.values())
+        values.append(datetime.utcnow().isoformat())
+        values.append(dish_id)
+
+        cursor.execute(
+            f"UPDATE dishes SET {', '.join(set_parts)}, updated_at = ? WHERE id = ?",
+            values,
+        )
+        conn.commit()
+        conn.close()
+        return True
+
+    return await _run_in_thread(_replace)
+
+async def toggle_favorite(dish_id: int, value: bool) -> bool:
+    return await update_dish(dish_id, {"is_favorite": 1 if value else 0})
+
+
+async def list_favorites() -> List[Dict[str, Any]]:
+    def _list() -> List[Dict[str, Any]]:
+        conn = get_db_connection()
+        cursor = conn.cursor()
+        cursor.execute("SELECT id FROM dishes WHERE is_favorite = 1 ORDER BY name")
+        ids = [row[0] for row in cursor.fetchall()]
+        conn.close()
+        return ids
+
+    dish_ids = await _run_in_thread(_list)
+    favorites: List[Dict[str, Any]] = []
+    for dish_id in dish_ids:
+        dish = await get_dish_by_id(dish_id)
+        if dish:
+            favorites.append(dish)
+    return favorites
+
+
+async def get_dashboard_summary(user_id: str) -> Dict[str, Any]:
+    def _summary() -> Dict[str, Any]:
+        conn = get_db_connection()
+        cursor = conn.cursor()
+        cursor.execute("SELECT COUNT(*) FROM dishes")
+        total_dishes = cursor.fetchone()[0]
+        cursor.execute("SELECT COUNT(*) FROM dishes WHERE is_favorite = 1")
+        favorite_count = cursor.fetchone()[0]
+        cursor.execute(
+            "SELECT COUNT(*) FROM meal_plans WHERE user_id = ? AND plan_date >= date('now')",
+            (user_id,),
+        )
+        upcoming = cursor.fetchone()[0]
+        conn.close()
+        return {
+            "total_dishes": total_dishes,
+            "favorite_count": favorite_count,
+            "upcoming": upcoming,
+        }
+
+    return await _run_in_thread(_summary)
+
+
+async def create_meal_plan(
+    user_id: str,
+    chat_id: int,
+    dish_id: int,
+    plan_date: str,
+    meal_type: str,
+    servings: float,
+    notes: Optional[str] = None,
+) -> int:
+    def _create() -> int:
+        conn = get_db_connection()
+        cursor = conn.cursor()
+        cursor.execute(
+            """
+            INSERT INTO meal_plans (user_id, chat_id, dish_id, plan_date, meal_type, servings, notes)
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+            """,
+            (user_id, chat_id, dish_id, plan_date, meal_type, servings, notes),
+        )
+        plan_id = cursor.lastrowid
+        conn.commit()
+        conn.close()
+        return plan_id
+
+    return await _run_in_thread(_create)
+
+
+async def get_meal_plans_in_range(
+    user_id: str,
+    start_date: str,
+    end_date: str,
+) -> List[Dict[str, Any]]:
+    def _fetch() -> List[Dict[str, Any]]:
+        conn = get_db_connection()
+        cursor = conn.cursor()
+        cursor.execute(
+            """
+            SELECT mp.id, mp.plan_date, mp.meal_type, mp.servings, mp.notes,
+                   d.id as dish_id, d.name, d.category, d.cuisine, d.servings as base_servings
+            FROM meal_plans mp
+            JOIN dishes d ON d.id = mp.dish_id
+            WHERE mp.user_id = ? AND mp.plan_date BETWEEN ? AND ?
+            ORDER BY mp.plan_date, mp.meal_type
+            """,
+            (user_id, start_date, end_date),
+        )
+        rows = cursor.fetchall()
+        conn.close()
+        return [dict(row) for row in rows]
+
+    return await _run_in_thread(_fetch)
+
+
+async def delete_meal_plan(plan_id: int, user_id: str) -> bool:
+    def _delete() -> bool:
+        conn = get_db_connection()
+        cursor = conn.cursor()
+        cursor.execute(
+            "DELETE FROM meal_plans WHERE id = ? AND user_id = ?",
+            (plan_id, user_id),
+        )
+        affected = cursor.rowcount > 0
+        conn.commit()
+        conn.close()
+        return affected
+
+    return await _run_in_thread(_delete)
+
+
+async def log_action(user_id: str, dish_id: Optional[int], action: str, payload: Optional[Dict[str, Any]] = None) -> None:
+    payload_json = json.dumps(payload, ensure_ascii=False) if payload else None
+
+    def _log() -> None:
+        conn = get_db_connection()
+        cursor = conn.cursor()
+        cursor.execute(
+            "INSERT INTO user_actions (user_id, dish_id, action, payload) VALUES (?, ?, ?, ?)",
+            (user_id, dish_id, action, payload_json),
+        )
+        conn.commit()
+        conn.close()
+
+    await _run_in_thread(_log)
+
+
+async def get_recent_actions(user_id: str, limit: int = 5) -> List[Dict[str, Any]]:
+    def _fetch() -> List[Dict[str, Any]]:
+        conn = get_db_connection()
+        cursor = conn.cursor()
+        cursor.execute(
+            "SELECT action, payload, created_at FROM user_actions WHERE user_id = ? ORDER BY created_at DESC LIMIT ?",
+            (user_id, limit),
+        )
+        rows = cursor.fetchall()
+        conn.close()
+        results: List[Dict[str, Any]] = []
+        for row in rows:
+            payload = json.loads(row["payload"]) if row["payload"] else None
+            results.append({
+                "action": row["action"],
+                "payload": payload,
+                "created_at": row["created_at"],
+            })
+        return results
+
+    return await _run_in_thread(_fetch)
+
+async def get_shopping_list(
+    user_id: str,
+    start_date: str,
+    end_date: str,
+) -> Dict[str, Any]:
+    def _calculate() -> Dict[str, Any]:
+        conn = get_db_connection()
+        cursor = conn.cursor()
+        cursor.execute(
+            """
+            SELECT mp.id as plan_id, mp.plan_date, mp.meal_type, mp.servings as planned_servings,
+                   d.id as dish_id, d.name as dish_name, d.servings as base_servings,
+                   di.name as ingredient_name, di.quantity, di.unit,
+                   di.calories, di.protein, di.fat, di.carbs
+            FROM meal_plans mp
+            JOIN dishes d ON d.id = mp.dish_id
+            LEFT JOIN dish_ingredients di ON di.dish_id = d.id
+            WHERE mp.user_id = ? AND mp.plan_date BETWEEN ? AND ?
+            ORDER BY mp.plan_date, d.name
+            """,
+            (user_id, start_date, end_date),
+        )
+        rows = cursor.fetchall()
+
+        aggregated: Dict[Tuple[str, Optional[str]], Dict[str, Any]] = {}
+        plans: Dict[int, Dict[str, Any]] = {}
+        for row in rows:
+            plan_id = row["plan_id"]
+            if plan_id not in plans:
+                plans[plan_id] = {
+                    "plan_id": plan_id,
+                    "plan_date": row["plan_date"],
+                    "meal_type": row["meal_type"],
+                    "dish_id": row["dish_id"],
+                    "dish_name": row["dish_name"],
+                    "planned_servings": row["planned_servings"],
+                    "base_servings": row["base_servings"],
+                }
+            ingredient_name = (row["ingredient_name"] or "").strip()
+            if not ingredient_name:
+                continue
+            base_servings = row["base_servings"] or 1
+            ratio = (row["planned_servings"] or 1) / base_servings
+            quantity = (row["quantity"] or 0) * ratio
+            key = (ingredient_name.lower(), row["unit"])
+            entry = aggregated.setdefault(
+                key,
+                {
+                    "name": ingredient_name,
+                    "unit": row["unit"],
+                    "quantity": 0.0,
+                    "calories": 0.0,
+                    "protein": 0.0,
+                    "fat": 0.0,
+                    "carbs": 0.0,
+                },
+            )
+            entry["quantity"] += quantity
+            if row["calories"] is not None:
+                entry["calories"] += (row["calories"] or 0) * ratio
+            if row["protein"] is not None:
+                entry["protein"] += (row["protein"] or 0) * ratio
+            if row["fat"] is not None:
+                entry["fat"] += (row["fat"] or 0) * ratio
+            if row["carbs"] is not None:
+                entry["carbs"] += (row["carbs"] or 0) * ratio
+
+        conn.close()
+        items = sorted(aggregated.values(), key=lambda item: item["name"].lower())
+        return {
+            "items": items,
+            "plans": list(plans.values()),
+        }
+
+    return await _run_in_thread(_calculate)
+
+
+async def add_reminder(
+    user_id: str,
+    chat_id: int,
+    remind_at: str,
+    message: str,
+    job_name: str,
+    dish_id: Optional[int] = None,
+    plan_id: Optional[int] = None,
+) -> int:
+    def _insert() -> int:
+        conn = get_db_connection()
+        cursor = conn.cursor()
+        cursor.execute(
+            """
+            INSERT INTO reminders (user_id, chat_id, dish_id, plan_id, remind_at, message, job_name)
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+            """,
+            (user_id, chat_id, dish_id, plan_id, remind_at, message, job_name),
+        )
+        reminder_id = cursor.lastrowid
+        conn.commit()
+        conn.close()
+        return reminder_id
+
+    return await _run_in_thread(_insert)
+
+
+async def get_pending_reminders() -> List[Dict[str, Any]]:
+    def _fetch() -> List[Dict[str, Any]]:
+        conn = get_db_connection()
+        cursor = conn.cursor()
+        cursor.execute(
+            "SELECT id, user_id, chat_id, dish_id, plan_id, remind_at, message, job_name FROM reminders"
+        )
+        rows = cursor.fetchall()
+        conn.close()
+        return [dict(row) for row in rows]
+
+    return await _run_in_thread(_fetch)
+
+
+async def remove_reminder(reminder_id: int) -> None:
+    def _remove() -> None:
+        conn = get_db_connection()
+        cursor = conn.cursor()
+        cursor.execute("DELETE FROM reminders WHERE id = ?", (reminder_id,))
+        conn.commit()
+        conn.close()
+
+    await _run_in_thread(_remove)
+
+
+async def remove_reminder_by_job(job_name: str) -> None:
+    def _remove() -> None:
+        conn = get_db_connection()
+        cursor = conn.cursor()
+        cursor.execute("DELETE FROM reminders WHERE job_name = ?", (job_name,))
+        conn.commit()
+        conn.close()
+
+    await _run_in_thread(_remove)
+
+
+async def get_user_statistics(user_id: str) -> Dict[str, Any]:
+    def _stats() -> Dict[str, Any]:
+        conn = get_db_connection()
+        cursor = conn.cursor()
+
+        cursor.execute("SELECT COUNT(*) FROM dishes")
+        total_dishes = cursor.fetchone()[0]
+
+        cursor.execute("SELECT COUNT(*) FROM dishes WHERE is_favorite = 1")
+        favorite_dishes = cursor.fetchone()[0]
+
+        cursor.execute(
+            """
+            SELECT category, COUNT(*) as cnt
+            FROM dishes
+            WHERE category IS NOT NULL AND category != ''
+            GROUP BY category
+            ORDER BY cnt DESC
+            LIMIT 5
+            """
+        )
+        top_categories = [{"category": row["category"], "count": row["cnt"]} for row in cursor.fetchall()]
+
+        cursor.execute(
+            """
+            SELECT d.name, COUNT(*) AS times
+            FROM meal_plans mp
+            JOIN dishes d ON d.id = mp.dish_id
+            WHERE mp.user_id = ?
+            GROUP BY mp.dish_id
+            ORDER BY times DESC
+            LIMIT 5
+            """,
+            (user_id,),
+        )
+        top_planned = [{"name": row["name"], "count": row["times"]} for row in cursor.fetchall()]
+
+        cursor.execute(
+            """
+            SELECT action, COUNT(*) AS cnt
+            FROM user_actions
+            WHERE user_id = ?
+            GROUP BY action
+            """,
+            (user_id,),
+        )
+        activity = {row["action"]: row["cnt"] for row in cursor.fetchall()}
+
+        conn.close()
+        return {
+            "total_dishes": total_dishes,
+            "favorite_dishes": favorite_dishes,
+            "top_categories": top_categories,
+            "top_planned": top_planned,
+            "activity": activity,
+        }
+
+    return await _run_in_thread(_stats)
+
+async def get_dish_suggestions_by_ingredients(available: Iterable[str]) -> List[Dict[str, Any]]:
+    normalized = {item.strip().lower() for item in available if item.strip()}
+    if not normalized:
+        return []
+
+    def _search() -> List[Dict[str, Any]]:
+        conn = get_db_connection()
+        cursor = conn.cursor()
+        cursor.execute(
+            "SELECT d.id, d.name FROM dishes d ORDER BY d.name"
+        )
+        dishes = cursor.fetchall()
+        results: List[Dict[str, Any]] = []
+        for dish in dishes:
+            cursor.execute(
+                "SELECT name FROM dish_ingredients WHERE dish_id = ?",
+                (dish["id"],),
+            )
+            ing_names = {row[0].strip().lower() for row in cursor.fetchall() if row[0]}
+            if not ing_names:
+                continue
+            have = ing_names & normalized
+            missing = sorted(ing_names - normalized)
+            coverage = len(have) / len(ing_names)
+            if have:
+                results.append(
+                    {
+                        "dish_id": dish["id"],
+                        "name": dish["name"],
+                        "matched": sorted(have),
+                        "missing": missing,
+                        "coverage": coverage,
+                    }
+                )
+        conn.close()
+        results.sort(key=lambda item: item["coverage"], reverse=True)
+        return results
+
+    return await _run_in_thread(_search)
+
+
+async def export_data(user_id: str) -> Dict[str, str]:
+    dishes = await list_dishes()
+    plans = await get_meal_plans_in_range(user_id, "1970-01-01", "2999-12-31")
+
+    dish_lines = [
+        "name,category,cuisine,servings,prep_time,cook_time,difficulty,is_favorite,tags,ingredients,recipe,description,notes"
+    ]
+    for dish in dishes:
+        tags = ";".join(dish.get("tags", []))
+        ingredients_text = "; ".join(
+            [
+                f"{ing['name']}|{ing.get('quantity', '')}|{ing.get('unit', '')}|{ing.get('calories', '')}|{ing.get('protein', '')}|{ing.get('fat', '')}|{ing.get('carbs', '')}"
+                for ing in dish.get("ingredients_list", [])
+            ]
+        )
+        line = ",".join(
+            [
+                f'"{str(dish.get(key, "") or "").replace("\"", "''")}"'
+                for key in [
+                    "name",
+                    "category",
+                    "cuisine",
+                    "servings",
+                    "prep_time",
+                    "cook_time",
+                    "difficulty",
+                    "is_favorite",
+                    None,
+                    None,
+                    None,
+                    "description",
+                    "notes",
+                ]
+            ]
+        )
+        # Replace placeholders for tags and ingredients, recipe
+        line_parts = line.split(",")
+        line_parts[8] = f'"{tags}"'
+        line_parts[9] = f'"{ingredients_text}"'
+        line_parts[10] = f'"{(dish.get("instructions") or dish.get("recipe") or "").replace("\"", "''")}"'
+        dish_lines.append(",".join(line_parts))
+
+    plan_lines = ["plan_date,meal_type,dish_name,servings,notes"]
+    for plan in plans:
+        plan_lines.append(
+            ",".join(
+                [
+                    plan.get("plan_date", ""),
+                    plan.get("meal_type", ""),
+                    plan.get("name", ""),
+                    str(plan.get("servings", "")),
+                    f'"{(plan.get("notes") or "").replace("\"", "''")}"',
+                ]
+            )
+        )
+
+    return {
+        "dishes.csv": "\n".join(dish_lines),
+        "plan.csv": "\n".join(plan_lines),
+    }
+
+
+async def import_dishes(rows: Iterable[Dict[str, Any]]) -> Dict[str, Any]:
+    added = 0
+    skipped = []
+    for row in rows:
+        name = row.get("name", "").strip()
+        if not name:
+            continue
+        existing = await get_dish_by_name(name)
+        if existing:
+            skipped.append(name)
+            continue
+
+        tags = row.get("tags", "")
+        tag_list = [tag.strip() for tag in tags.split(";") if tag.strip()]
+        ingredients_text = row.get("ingredients", "")
+        ingredient_entries: List[Dict[str, Any]] = []
+        if ingredients_text:
+            for chunk in ingredients_text.split(";"):
+                parts = [part.strip() for part in chunk.split("|")]
+                if not parts or not parts[0]:
+                    continue
+                while len(parts) < 7:
+                    parts.append("")
+                ingredient_entries.append(
+                    {
+                        "name": parts[0],
+                        "quantity": float(parts[1]) if parts[1] else None,
+                        "unit": parts[2] or None,
+                        "calories": float(parts[3]) if parts[3] else None,
+                        "protein": float(parts[4]) if parts[4] else None,
+                        "fat": float(parts[5]) if parts[5] else None,
+                        "carbs": float(parts[6]) if parts[6] else None,
+                    }
+                )
+        try:
+            await add_dish(
+                {
+                    "name": name,
+                    "category": row.get("category"),
+                    "cuisine": row.get("cuisine"),
+                    "servings": float(row.get("servings")) if row.get("servings") else 1,
+                    "prep_time": int(float(row.get("prep_time"))) if row.get("prep_time") else 0,
+                    "cook_time": int(float(row.get("cook_time"))) if row.get("cook_time") else 0,
+                    "difficulty": row.get("difficulty"),
+                    "is_favorite": str(row.get("is_favorite", "")).strip() in {"1", "true", "True"},
+                    "instructions": row.get("recipe") or row.get("instructions"),
+                    "description": row.get("description"),
+                    "notes": row.get("notes"),
+                },
+                ingredient_entries,
+                tag_list,
+            )
+            added += 1
+        except ValueError:
+            skipped.append(name)
+    return {"added": added, "skipped": skipped}
+
+
+
+async def set_dish_tags(dish_id: int, tags: Sequence[str]) -> bool:
+    def _set() -> bool:
+        conn = get_db_connection()
+        cursor = conn.cursor()
+        cursor.execute("SELECT id FROM dishes WHERE id = ?", (dish_id,))
+        if not cursor.fetchone():
+            conn.close()
+            return False
+        cursor.execute("DELETE FROM dish_tags WHERE dish_id = ?", (dish_id,))
+        for tag in tags:
+            clean_tag = tag.strip().lower()
+            if clean_tag:
+                cursor.execute(
+                    "INSERT OR IGNORE INTO dish_tags (dish_id, tag) VALUES (?, ?)",
+                    (dish_id, clean_tag),
+                )
+        conn.commit()
+        conn.close()
+        return True
+
+    return await _run_in_thread(_set)

--- a/handlers.py
+++ b/handlers.py
@@ -1,49 +1,312 @@
-from telegram import ReplyKeyboardMarkup
-from telegram.ext import CommandHandler, MessageHandler, filters
-from database import get_db_connection
+from __future__ import annotations
 
-# Функции-обработчики
+import io
+import zipfile
+from datetime import datetime, timedelta
+from typing import Dict, List
 
-async def start(update, context):
-    keyboard = [
-        ["Добавить блюдо", "Меню"],
-        ["Удалить блюдо", "Изменить блюдо"],
-        ["Добавить детали", "Помощь"]
+from telegram import (
+    InlineKeyboardButton,
+    InlineKeyboardMarkup,
+    InputFile,
+    ReplyKeyboardMarkup,
+    Update,
+)
+from telegram.ext import (
+    Application,
+    CallbackQueryHandler,
+    CommandHandler,
+    ContextTypes,
+    MessageHandler,
+    filters,
+)
+
+import database
+from states import (
+    add_details_handler,
+    add_dish_handler,
+    delete_dish_handler,
+    find_by_ingredients_handler,
+    import_handler,
+    plan_handler,
+    scale_dish_handler,
+    send_reminder_job,
+    edit_dish_handler,
+)
+from utils import (
+    build_main_keyboard_layout,
+    calculate_date_range,
+    format_dish_card,
+    format_plan_entries,
+    format_recent_actions,
+    format_shareable_recipe,
+    format_shopping_items,
+    format_statistics,
+)
+
+
+async def start(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    user_id = str(update.effective_user.id)
+    summary = await database.get_dashboard_summary(user_id)
+    recent = await database.get_recent_actions(user_id)
+    keyboard = ReplyKeyboardMarkup(
+        build_main_keyboard_layout(summary),
+        resize_keyboard=True,
+    )
+    message_lines = [
+        "Привет! Я помогу вести меню, планировать питание и составлять списки покупок.",
+        f"Всего блюд: {summary.get('total_dishes', 0)}",
+        f"Избранных блюд: {summary.get('favorite_count', 0)}",
+        f"Запланированных приёмов пищи: {summary.get('upcoming', 0)}",
     ]
-    reply_markup = ReplyKeyboardMarkup(keyboard, one_time_keyboard=True, resize_keyboard=True)
-    await update.message.reply_text("Привет! Я твой бот-помощник с едой. Выберите команду:", reply_markup=reply_markup)
+    recent_text = format_recent_actions(recent)
+    if recent_text:
+        message_lines.append("\n" + recent_text)
+    await update.message.reply_text("\n".join(message_lines), reply_markup=keyboard)
 
-async def list_dishes(update, context):
-    conn = get_db_connection()
-    cursor = conn.cursor()
-    cursor.execute("SELECT name FROM dishes")
-    dishes = cursor.fetchall()
-    
-    if not dishes:
-        await update.message.reply_text("Меню пока пустое.")
-        return
-    
-    dishes_list = "\n".join([dish[0] for dish in dishes])
-    await update.message.reply_text(f"Текущие блюда в меню:\n{dishes_list}")
 
-async def help_command(update, context):
+async def help_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     help_text = (
-        "/start - Начать работу с ботом\n"
-        "/add_dish - Добавить блюдо\n"
-        "/menu - Показать текущее меню\n"
-        "/delete_dish - Удалить блюдо\n"
-        "/edit_dish - Изменить название блюда\n"
-        "/add_details - Добавить ингредиенты и рецепт\n"
-        "/help - Показать это сообщение"
+        "Доступные команды:\n"
+        "/start — показать главное меню\n"
+        "/add_dish — добавить новое блюдо\n"
+        "/menu — список всех блюд\n"
+        "/view <название> — показать карточку блюда\n"
+        "/plan — добавить блюдо в план питания\n"
+        "/shopping — сформировать список покупок\n"
+        "/favorites — показать избранные блюда\n"
+        "/stats — статистика использования\n"
+        "/find — поиск блюд по ингредиентам\n"
+        "/import — импорт блюд из CSV\n"
+        "/export — экспорт всех данных\n"
+        "/cancel — отменить текущий диалог"
     )
     await update.message.reply_text(help_text)
 
-def register_handlers(app):
+
+async def list_dishes(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    dishes = await database.list_dishes()
+    message = update.effective_message
+    if not dishes:
+        await message.reply_text("Меню пустое. Добавьте блюдо с помощью команды 'Добавить блюдо'.")
+        return
+    dish_names = "\n".join(f"• {dish['name']}" for dish in dishes)
+    buttons: List[List[InlineKeyboardButton]] = []
+    for dish in dishes[:30]:  # ограничимся 30 кнопками для компактности
+        buttons.append([InlineKeyboardButton(dish["name"], callback_data=f"view_dish:{dish['id']}")])
+    keyboard = InlineKeyboardMarkup(buttons) if buttons else None
+    await message.reply_text("Текущие блюда:\n" + dish_names, reply_markup=keyboard)
+
+
+async def view_dish_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    if not context.args:
+        await update.message.reply_text("Укажите название блюда после команды, например: /view Борщ")
+        return
+    name = " ".join(context.args)
+    dish = await database.get_dish_by_name(name)
+    if not dish:
+        suggestions = await database.search_dish_names(name, limit=3)
+        if suggestions:
+            names = ", ".join(item["name"] for item in suggestions)
+            await update.message.reply_text(f"Блюдо не найдено. Возможно, вы искали: {names}")
+        else:
+            await update.message.reply_text("Блюдо не найдено. Добавьте его в меню.")
+        return
+    await update.message.reply_text(format_dish_card(dish))
+
+
+async def view_dish_callback(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    query = update.callback_query
+    await query.answer()
+    dish_id = int(query.data.split(":", 1)[1])
+    dish = await database.get_dish_by_id(dish_id)
+    if not dish:
+        await query.edit_message_text("Блюдо не найдено или было удалено.")
+        return
+    keyboard = InlineKeyboardMarkup(
+        [
+            [
+                InlineKeyboardButton(
+                    "★ Убрать из избранного" if dish.get("is_favorite") else "⭐️ В избранное",
+                    callback_data=f"toggle_favorite:{dish_id}",
+                ),
+                InlineKeyboardButton("🗓 В план", callback_data=f"plan_from_dish:{dish_id}"),
+            ],
+            [
+                InlineKeyboardButton("📏 Масштабировать", callback_data=f"scale_dish:{dish_id}"),
+                InlineKeyboardButton("📄 Экспорт блюда", callback_data=f"export_dish:{dish_id}"),
+            ],
+            [
+                InlineKeyboardButton("📤 Поделиться", callback_data=f"share_dish:{dish_id}"),
+            ],
+        ]
+    )
+    await query.message.reply_text(format_dish_card(dish), reply_markup=keyboard)
+
+
+async def toggle_favorite_callback(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    query = update.callback_query
+    await query.answer()
+    dish_id = int(query.data.split(":", 1)[1])
+    dish = await database.get_dish_by_id(dish_id)
+    if not dish:
+        await query.message.reply_text("Блюдо не найдено.")
+        return
+    new_value = not bool(dish.get("is_favorite"))
+    await database.toggle_favorite(dish_id, new_value)
+    await database.log_action(str(update.effective_user.id), dish_id, "favorites_updated", {"is_favorite": new_value})
+    text = "Добавлено в избранное" if new_value else "Удалено из избранного"
+    await query.message.reply_text(text)
+
+
+async def share_dish_callback(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    query = update.callback_query
+    await query.answer()
+    dish_id = int(query.data.split(":", 1)[1])
+    dish = await database.get_dish_by_id(dish_id)
+    if not dish:
+        await query.message.reply_text("Блюдо не найдено для отправки.")
+        return
+    await query.message.reply_text("Скопируйте текст и поделитесь им:\n\n" + format_shareable_recipe(dish))
+
+
+async def export_dish_callback(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    query = update.callback_query
+    await query.answer()
+    dish_id = int(query.data.split(":", 1)[1])
+    dish = await database.get_dish_by_id(dish_id)
+    if not dish:
+        await query.message.reply_text("Блюдо не найдено для экспорта.")
+        return
+    buffer = io.BytesIO()
+    buffer.write(format_shareable_recipe(dish).encode("utf-8"))
+    buffer.seek(0)
+    filename = f"{dish['name']}.txt".replace("/", "-")
+    await query.message.reply_document(InputFile(buffer, filename=filename), caption="Карточка блюда готова к скачиванию.")
+
+
+async def show_favorites(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    favorites = await database.list_favorites()
+    message = update.effective_message
+    if not favorites:
+        await message.reply_text("Избранных блюд пока нет. Добавьте их из карточки блюда кнопкой '⭐️'.")
+        return
+    lines = ["Избранные блюда:"]
+    for dish in favorites:
+        lines.append(f"• {dish['name']}")
+    keyboard = InlineKeyboardMarkup(
+        [[InlineKeyboardButton(dish["name"], callback_data=f"view_dish:{dish['id']}")] for dish in favorites[:30]]
+    )
+    await message.reply_text("\n".join(lines), reply_markup=keyboard)
+
+
+async def plan_overview(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    user_id = str(update.effective_user.id)
+    start_date, end_date = calculate_date_range(7)
+    plans = await database.get_meal_plans_in_range(user_id, start_date, end_date)
+    keyboard = InlineKeyboardMarkup([[InlineKeyboardButton("➕ Добавить блюдо", callback_data="plan_create")]])
+    await update.effective_message.reply_text(
+        format_plan_entries(plans) + f"\n\nПоказываются планы на период {start_date} — {end_date}.",
+        reply_markup=keyboard,
+    )
+
+
+async def shopping_list_handler(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    user_id = str(update.effective_user.id)
+    start_date, end_date = calculate_date_range(7)
+    result = await database.get_shopping_list(user_id, start_date, end_date)
+    await update.effective_message.reply_text(
+        format_shopping_items(result.get("items", []))
+        + f"\n\nДиапазон: {start_date} — {end_date}",
+    )
+    await database.log_action(user_id, None, "shopping_viewed", {"items": len(result.get("items", []))})
+
+
+async def statistics_handler(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    user_id = str(update.effective_user.id)
+    stats = await database.get_user_statistics(user_id)
+    recent = await database.get_recent_actions(user_id)
+    await update.effective_message.reply_text(format_statistics(stats, recent))
+    await database.log_action(user_id, None, "statistics_viewed", None)
+
+
+async def export_all_handler(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    user_id = str(update.effective_user.id)
+    data = await database.export_data(user_id)
+    buffer = io.BytesIO()
+    with zipfile.ZipFile(buffer, "w", zipfile.ZIP_DEFLATED) as archive:
+        for filename, content in data.items():
+            archive.writestr(filename, content)
+    buffer.seek(0)
+    await update.effective_message.reply_document(
+        InputFile(buffer, filename="menu_export.zip"),
+        caption="Экспорт завершён.",
+    )
+
+
+async def schedule_existing_reminders(application: Application) -> None:
+    reminders = await database.get_pending_reminders()
+    now = datetime.now()
+    for reminder in reminders:
+        try:
+            remind_at = datetime.fromisoformat(reminder["remind_at"])
+        except ValueError:
+            continue
+        delta = remind_at - now
+        when = max(delta, timedelta(seconds=1))
+        job = application.job_queue.run_once(
+            send_reminder_job,
+            when=when,
+            name=reminder.get("job_name"),
+            data={
+                "chat_id": reminder["chat_id"],
+                "message": reminder["message"],
+                "reminder_time": reminder["remind_at"],
+                "reminder_id": reminder["id"],
+                "plan_id": reminder.get("plan_id"),
+                "dish_id": reminder.get("dish_id"),
+                "user_id": reminder.get("user_id"),
+            },
+        )
+        if job and job.data is not None:
+            job.data["reminder_id"] = reminder["id"]
+
+
+async def post_init(application: Application) -> None:
+    await schedule_existing_reminders(application)
+
+
+def register_handlers(app: Application) -> None:
     app.add_handler(CommandHandler("start", start))
-    from states import add_details_handler, dish_handler, edit_dish_handler, delete_dish_handler  # Импорт состояний здесь
-    app.add_handler(dish_handler)
+    app.add_handler(CommandHandler("help", help_command))
+    app.add_handler(CommandHandler("menu", list_dishes))
+    app.add_handler(CommandHandler("view", view_dish_command))
+    app.add_handler(CommandHandler("favorites", show_favorites))
+    app.add_handler(CommandHandler("shopping", shopping_list_handler))
+    app.add_handler(CommandHandler("stats", statistics_handler))
+    app.add_handler(CommandHandler("export", export_all_handler))
+
+    app.add_handler(add_dish_handler)
+    app.add_handler(add_details_handler)
     app.add_handler(edit_dish_handler)
     app.add_handler(delete_dish_handler)
-    app.add_handler(add_details_handler)
+    app.add_handler(plan_handler)
+    app.add_handler(import_handler)
+    app.add_handler(find_by_ingredients_handler)
+    app.add_handler(scale_dish_handler)
+
     app.add_handler(MessageHandler(filters.Regex("^(Меню)$"), list_dishes))
+    app.add_handler(MessageHandler(filters.Regex("^(Избранное)$"), show_favorites))
+    app.add_handler(MessageHandler(filters.Regex("^(Список покупок)$"), shopping_list_handler))
+    app.add_handler(MessageHandler(filters.Regex("^(Статистика)$"), statistics_handler))
+    app.add_handler(MessageHandler(filters.Regex("^(Экспорт)$"), export_all_handler))
+    app.add_handler(MessageHandler(filters.Regex("^(План питания)$"), plan_overview))
     app.add_handler(MessageHandler(filters.Regex("^(Помощь)$"), help_command))
+
+    app.add_handler(CallbackQueryHandler(view_dish_callback, pattern="^view_dish:"))
+    app.add_handler(CallbackQueryHandler(toggle_favorite_callback, pattern="^toggle_favorite:"))
+    app.add_handler(CallbackQueryHandler(export_dish_callback, pattern="^export_dish:"))
+    app.add_handler(CallbackQueryHandler(share_dish_callback, pattern="^share_dish:"))
+
+    app.post_init = post_init
+

--- a/states.py
+++ b/states.py
@@ -1,108 +1,931 @@
-from telegram.ext import ConversationHandler, MessageHandler, filters, CommandHandler
-from handlers import start
-from database import get_db_connection  # Импорт функции для подключения к базе данных
+from __future__ import annotations
 
-# Определение состояний
-ADDING_DISH, ADDING_INGREDIENTS, ADDING_RECIPE, EDITING_DISH, DELETING_DISH, ADDING_DETAILS = range(6)
+import csv
+import io
+from datetime import date, datetime, time, timedelta
+from typing import Any, Dict, List, Optional
 
-async def add_dish(update, context):
-    await update.message.reply_text("Напишите название блюда, которое вы хотите добавить.")
-    return ADDING_DISH
-
-async def save_dish(update, context):
-    dish_name = update.message.text
-    conn = get_db_connection()  # Подключение к базе данных
-    cursor = conn.cursor()
-    cursor.execute("INSERT INTO dishes (name) VALUES (?)", (dish_name,))
-    conn.commit()
-    await update.message.reply_text(f'Блюдо "{dish_name}" добавлено в меню.')
-    return ConversationHandler.END
-
-async def add_ingredients(update, context):
-    context.user_data['dish_name'] = update.message.text
-    await update.message.reply_text("Введите ингредиенты для этого блюда в формате: название_ингредиента, количество, единица_измерения.")
-    return ADDING_INGREDIENTS
-
-async def add_recipe(update, context):
-    context.user_data['ingredients'] = update.message.text
-    await update.message.reply_text("Теперь введите рецепт.")
-    return ADDING_RECIPE
-
-async def save_details(update, context):
-    recipe = update.message.text
-    dish_name = context.user_data.get('dish_name')
-    ingredients = context.user_data.get('ingredients')
-    
-    conn = get_db_connection()
-    cursor = conn.cursor()
-    cursor.execute("INSERT INTO dishes (name, ingredients, recipe) VALUES (?, ?, ?)", (dish_name, ingredients, recipe))
-    conn.commit()
-    await update.message.reply_text(f'Детали для блюда "{dish_name}" сохранены.')
-    return ConversationHandler.END
-
-async def edit_dish(update, context):
-    await update.message.reply_text("Напишите старое название блюда.")
-    return EDITING_DISH
-
-async def save_edited_dish(update, context):
-    old_name = context.user_data.get("old_name", "")
-    new_name = update.message.text
-    conn = get_db_connection()
-    cursor = conn.cursor()
-    cursor.execute("UPDATE dishes SET name = ? WHERE name = ?", (new_name, old_name))
-    conn.commit()
-    if cursor.rowcount == 0:
-        await update.message.reply_text(f'Блюдо "{old_name}" не найдено в меню.')
-    else:
-        await update.message.reply_text(f'Блюдо "{old_name}" было переименовано в "{new_name}".')
-    return ConversationHandler.END
-
-async def delete_dish(update, context):
-    await update.message.reply_text("Напишите название блюда, которое вы хотите удалить.")
-    return DELETING_DISH
-
-async def confirm_delete_dish(update, context):
-    dish_name = update.message.text
-    conn = get_db_connection()
-    cursor = conn.cursor()
-    cursor.execute("DELETE FROM dishes WHERE name = ?", (dish_name,))
-    conn.commit()
-    if cursor.rowcount == 0:
-        await update.message.reply_text(f'Блюдо "{dish_name}" не найдено в меню.')
-    else:
-        await update.message.reply_text(f'Блюдо "{dish_name}" удалено из меню.')
-    return ConversationHandler.END
-
-add_details_handler = ConversationHandler(
-    entry_points=[MessageHandler(filters.Regex("^(Добавить детали)$"), add_ingredients)],
-    states={
-        ADDING_DETAILS: [MessageHandler(filters.TEXT & ~filters.COMMAND, add_ingredients)],
-        ADDING_INGREDIENTS: [MessageHandler(filters.TEXT & ~filters.COMMAND, add_recipe)],
-        ADDING_RECIPE: [MessageHandler(filters.TEXT & ~filters.COMMAND, save_details)],
-    },
-    fallbacks=[CommandHandler("start", start)]
+from telegram import (
+    InlineKeyboardButton,
+    InlineKeyboardMarkup,
+    ReplyKeyboardMarkup,
+    ReplyKeyboardRemove,
+    Update,
+)
+from telegram.ext import (
+    CallbackQueryHandler,
+    CommandHandler,
+    ConversationHandler,
+    ContextTypes,
+    MessageHandler,
+    filters,
 )
 
-dish_handler = ConversationHandler(
-    entry_points=[MessageHandler(filters.Regex("^(Добавить блюдо)$"), add_dish)],
+import database
+from utils import (
+    DIFFICULTY_LEVELS,
+    FINISH_INGREDIENT_KEYWORDS,
+    MAIN_CATEGORIES,
+    MEAL_TYPES,
+    NO_ANSWERS,
+    SKIP_KEYWORD,
+    YES_ANSWERS,
+    format_dish_card,
+    format_scaled_ingredients,
+    format_search_results,
+    parse_date_input,
+    parse_float,
+    parse_ingredient_input,
+    parse_int,
+    parse_tags,
+    parse_time_input,
+)
+
+(
+    ADD_NAME,
+    ADD_CATEGORY,
+    ADD_CUISINE,
+    ADD_SERVINGS,
+    ADD_PREP_TIME,
+    ADD_COOK_TIME,
+    ADD_DIFFICULTY,
+    ADD_DESCRIPTION,
+    ADD_INGREDIENTS,
+    ADD_INSTRUCTIONS,
+    ADD_TAGS,
+    DETAILS_SELECT,
+    DETAILS_INGREDIENTS,
+    DETAILS_INSTRUCTIONS,
+    DETAILS_TAGS,
+    EDIT_SELECT,
+    EDIT_FIELD,
+    EDIT_VALUE,
+    DELETE_SELECT,
+    DELETE_CONFIRM,
+    PLAN_CHOOSE_DISH,
+    PLAN_SET_DATE,
+    PLAN_SET_MEAL,
+    PLAN_SET_SERVINGS,
+    PLAN_SET_NOTES,
+    PLAN_CONFIRM_REMINDER,
+    PLAN_SET_REMINDER_TIME,
+    IMPORT_WAITING_FILE,
+    FIND_BY_INGREDIENTS_INPUT,
+    SCALE_WAITING,
+) = range(30)
+
+EDITABLE_FIELDS = {
+    "Название": "name",
+    "Категория": "category",
+    "Кухня": "cuisine",
+    "Порции": "servings",
+    "Время подготовки (мин)": "prep_time",
+    "Время готовки (мин)": "cook_time",
+    "Сложность": "difficulty",
+    "Описание": "description",
+    "Источник": "source",
+    "Заметки": "notes",
+    "Теги": "tags",
+    "Избранное": "is_favorite",
+    "Готово": None,
+}
+
+
+async def cancel(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
+    if update.callback_query:
+        await update.callback_query.answer("Действие отменено")
+        await update.callback_query.edit_message_text("Действие отменено")
+    elif update.message:
+        await update.message.reply_text(
+            "Действие отменено. Возвращаю основное меню.",
+            reply_markup=ReplyKeyboardRemove(),
+        )
+    return ConversationHandler.END
+
+
+def _categories_keyboard() -> ReplyKeyboardMarkup:
+    rows = [[category] for category in MAIN_CATEGORIES]
+    rows.append([SKIP_KEYWORD])
+    return ReplyKeyboardMarkup(rows, resize_keyboard=True, one_time_keyboard=True)
+
+
+def _difficulty_keyboard() -> ReplyKeyboardMarkup:
+    rows = [[difficulty] for difficulty in DIFFICULTY_LEVELS]
+    rows.append([SKIP_KEYWORD])
+    return ReplyKeyboardMarkup(rows, resize_keyboard=True, one_time_keyboard=True)
+
+
+def _meal_type_keyboard() -> ReplyKeyboardMarkup:
+    rows = [[meal] for meal in MEAL_TYPES]
+    return ReplyKeyboardMarkup(rows, resize_keyboard=True, one_time_keyboard=True)
+
+
+def _yes_no_keyboard() -> ReplyKeyboardMarkup:
+    return ReplyKeyboardMarkup([["Да", "Нет"]], resize_keyboard=True, one_time_keyboard=True)
+
+
+async def add_dish_entry(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
+    context.user_data["add_dish"] = {"data": {}, "ingredients": [], "tags": []}
+    await update.message.reply_text("Введите название блюда.", reply_markup=ReplyKeyboardRemove())
+    return ADD_NAME
+
+
+async def add_dish_name(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
+    name = update.message.text.strip()
+    if not name:
+        await update.message.reply_text("Название не может быть пустым. Попробуйте ещё раз.")
+        return ADD_NAME
+    existing = await database.get_dish_by_name(name)
+    if existing:
+        await update.message.reply_text(
+            "Такое блюдо уже есть. Вы можете выбрать другое название или отредактировать существующее через "
+            "'Изменить блюдо'.",
+        )
+        return ADD_NAME
+    context.user_data.setdefault("add_dish", {})["data"]["name"] = name
+    await update.message.reply_text(
+        "Укажите категорию блюда или нажмите 'Пропустить'.",
+        reply_markup=_categories_keyboard(),
+    )
+    return ADD_CATEGORY
+
+
+async def add_dish_category(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
+    text = update.message.text.strip()
+    if text != SKIP_KEYWORD:
+        context.user_data["add_dish"]["data"]["category"] = text
+    await update.message.reply_text(
+        "Укажите кухню (например, Русская, Итальянская) или нажмите 'Пропустить'.",
+        reply_markup=ReplyKeyboardMarkup([[SKIP_KEYWORD]], resize_keyboard=True, one_time_keyboard=True),
+    )
+    return ADD_CUISINE
+
+
+async def add_dish_cuisine(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
+    text = update.message.text.strip()
+    if text != SKIP_KEYWORD:
+        context.user_data["add_dish"]["data"]["cuisine"] = text
+    await update.message.reply_text(
+        "Сколько порций рассчитан рецепт? Введите число.",
+        reply_markup=ReplyKeyboardRemove(),
+    )
+    return ADD_SERVINGS
+
+
+async def add_dish_servings(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
+    servings = parse_float(update.message.text)
+    if servings is None or servings <= 0:
+        await update.message.reply_text("Введите положительное число порций.")
+        return ADD_SERVINGS
+    context.user_data["add_dish"]["data"]["servings"] = servings
+    await update.message.reply_text("Сколько минут требуется на подготовку? Укажите число или 0, если не нужно.")
+    return ADD_PREP_TIME
+
+
+async def add_dish_prep_time(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
+    value = parse_int(update.message.text)
+    if value is None or value < 0:
+        await update.message.reply_text("Введите неотрицательное число минут подготовки.")
+        return ADD_PREP_TIME
+    context.user_data["add_dish"]["data"]["prep_time"] = value
+    await update.message.reply_text("Сколько минут занимает готовка? Укажите число или 0, если неизвестно.")
+    return ADD_COOK_TIME
+
+
+async def add_dish_cook_time(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
+    value = parse_int(update.message.text)
+    if value is None or value < 0:
+        await update.message.reply_text("Введите неотрицательное число минут готовки.")
+        return ADD_COOK_TIME
+    context.user_data["add_dish"]["data"]["cook_time"] = value
+    await update.message.reply_text(
+        "Укажите сложность рецепта или нажмите 'Пропустить'.",
+        reply_markup=_difficulty_keyboard(),
+    )
+    return ADD_DIFFICULTY
+
+
+async def add_dish_difficulty(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
+    text = update.message.text.strip()
+    if text != SKIP_KEYWORD:
+        context.user_data["add_dish"]["data"]["difficulty"] = text
+    await update.message.reply_text(
+        "Добавьте краткое описание блюда или нажмите 'Пропустить'.",
+        reply_markup=ReplyKeyboardMarkup([[SKIP_KEYWORD]], resize_keyboard=True, one_time_keyboard=True),
+    )
+    return ADD_DESCRIPTION
+
+
+async def add_dish_description(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
+    text = update.message.text.strip()
+    if text != SKIP_KEYWORD:
+        context.user_data["add_dish"]["data"]["description"] = text
+    await update.message.reply_text(
+        "Перечисляйте ингредиенты по одному в формате:\n"
+        "Название; количество; единица; калории; белки; жиры; углеводы.\n"
+        "Когда закончите, напишите 'Готово'.",
+        reply_markup=ReplyKeyboardMarkup([["Готово"]], resize_keyboard=True, one_time_keyboard=True),
+    )
+    return ADD_INGREDIENTS
+
+
+async def add_dish_ingredients(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
+    text = update.message.text.strip()
+    lower = text.lower()
+    data = context.user_data["add_dish"]
+    if lower in FINISH_INGREDIENT_KEYWORDS:
+        if not data["ingredients"]:
+            await update.message.reply_text(
+                "Чтобы бот мог построить список покупок и подсчитать калории, добавьте хотя бы один ингредиент.",
+            )
+            return ADD_INGREDIENTS
+        await update.message.reply_text("Теперь отправьте рецепт блюда." , reply_markup=ReplyKeyboardRemove())
+        return ADD_INSTRUCTIONS
+    try:
+        ingredient = parse_ingredient_input(text)
+    except ValueError as error:
+        await update.message.reply_text(f"Не удалось распознать ингредиент: {error}")
+        return ADD_INGREDIENTS
+    data["ingredients"].append(ingredient)
+    await update.message.reply_text("Добавлено. Введите следующий ингредиент или напишите 'Готово'.")
+    return ADD_INGREDIENTS
+
+
+async def add_dish_instructions(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
+    instructions = update.message.text.strip()
+    if not instructions:
+        await update.message.reply_text("Рецепт не может быть пустым. Опишите шаги приготовления.")
+        return ADD_INSTRUCTIONS
+    context.user_data["add_dish"]["data"]["instructions"] = instructions
+    await update.message.reply_text(
+        "Перечислите теги через запятую (например: веганское, быстро) или нажмите 'Пропустить'.",
+        reply_markup=ReplyKeyboardMarkup([[SKIP_KEYWORD]], resize_keyboard=True, one_time_keyboard=True),
+    )
+    return ADD_TAGS
+
+
+async def add_dish_tags(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
+    text = update.message.text.strip()
+    tags: List[str] = []
+    if text != SKIP_KEYWORD:
+        tags = parse_tags(text)
+    payload = context.user_data.pop("add_dish", {})
+    data = payload.get("data", {})
+    ingredients = payload.get("ingredients", [])
+    user_id = str(update.effective_user.id)
+    try:
+        dish_id = await database.add_dish(data, ingredients, tags)
+    except ValueError as error:
+        await update.message.reply_text(str(error))
+        return ConversationHandler.END
+    dish = await database.get_dish_by_id(dish_id)
+    if dish:
+        await update.message.reply_text(
+            "Блюдо успешно сохранено! Вот его карточка:\n" + format_dish_card(dish),
+            reply_markup=ReplyKeyboardRemove(),
+        )
+    await database.log_action(user_id, dish_id, "dish_added", {"name": data.get("name")})
+    return ConversationHandler.END
+
+
+async def add_details_entry(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
+    context.user_data["details"] = {"ingredients": []}
+    await update.message.reply_text("Введите название блюда, которое хотите дополнить.")
+    return DETAILS_SELECT
+
+
+async def add_details_select(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
+    name = update.message.text.strip()
+    dish = await database.get_dish_by_name(name)
+    if not dish:
+        matches = await database.search_dish_names(name, limit=3)
+        if matches:
+            suggestions = ", ".join(match["name"] for match in matches)
+            await update.message.reply_text(f"Не нашёл точного совпадения. Может быть, вы имели в виду: {suggestions}? Попробуйте ещё раз.")
+        else:
+            await update.message.reply_text("Блюдо не найдено. Убедитесь, что оно добавлено в меню.")
+        return DETAILS_SELECT
+    context.user_data["details"]["dish"] = dish
+    context.user_data["details"]["ingredients"] = []
+    await update.message.reply_text(
+        "Текущая карточка блюда:\n" + format_dish_card(dish)
+    )
+    await update.message.reply_text(
+        "Введите новые ингредиенты в формате 'Название; количество; единица; ...'.\n"
+        "Отправьте несколько сообщений по одному ингредиенту. Напишите 'Готово', чтобы оставить текущий список.",
+        reply_markup=ReplyKeyboardMarkup([["Готово"], [SKIP_KEYWORD]], resize_keyboard=True, one_time_keyboard=True),
+    )
+    return DETAILS_INGREDIENTS
+
+
+async def add_details_ingredients(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
+    text = update.message.text.strip()
+    lower = text.lower()
+    details_data = context.user_data["details"]
+    if lower in FINISH_INGREDIENT_KEYWORDS or text == SKIP_KEYWORD:
+        if not details_data["ingredients"]:
+            details_data["ingredients"] = None  # оставить без изменений
+        await update.message.reply_text(
+            "Опишите новый рецепт или нажмите 'Пропустить', чтобы оставить существующий.",
+            reply_markup=ReplyKeyboardMarkup([[SKIP_KEYWORD]], resize_keyboard=True, one_time_keyboard=True),
+        )
+        return DETAILS_INSTRUCTIONS
+    try:
+        ingredient = parse_ingredient_input(text)
+    except ValueError as error:
+        await update.message.reply_text(f"Ошибка: {error}. Попробуйте ещё раз.")
+        return DETAILS_INGREDIENTS
+    details_data["ingredients"].append(ingredient)
+    await update.message.reply_text("Добавлено. Введите следующий ингредиент или напишите 'Готово'.")
+    return DETAILS_INGREDIENTS
+
+
+async def add_details_instructions(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
+    text = update.message.text.strip()
+    if text != SKIP_KEYWORD:
+        context.user_data["details"]["instructions"] = text
+    await update.message.reply_text(
+        "Введите обновлённые теги или нажмите 'Пропустить'.",
+        reply_markup=ReplyKeyboardMarkup([[SKIP_KEYWORD]], resize_keyboard=True, one_time_keyboard=True),
+    )
+    return DETAILS_TAGS
+
+
+async def add_details_tags(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
+    text = update.message.text.strip()
+    details_data = context.user_data.pop("details", {})
+    dish = details_data.get("dish")
+    if not dish:
+        await update.message.reply_text("Что-то пошло не так — блюдо не найдено.")
+        return ConversationHandler.END
+    ingredients_input = details_data.get("ingredients")
+    if ingredients_input is None:
+        ingredients = dish.get("ingredients_list", [])
+    else:
+        ingredients = ingredients_input
+    instructions = details_data.get("instructions") if "instructions" in details_data else None
+    tags = dish.get("tags") if text == SKIP_KEYWORD else parse_tags(text)
+    await database.replace_dish_details(dish["id"], ingredients, instructions=instructions, tags=tags)
+    updated = await database.get_dish_by_id(dish["id"])
+    await update.message.reply_text(
+        "Блюдо обновлено:\n" + format_dish_card(updated),
+        reply_markup=ReplyKeyboardRemove(),
+    )
+    await database.log_action(str(update.effective_user.id), dish["id"], "details_updated", {"name": dish.get("name")})
+    return ConversationHandler.END
+
+
+async def edit_dish_entry(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
+    await update.message.reply_text("Введите название блюда, которое хотите изменить.")
+    context.user_data["edit_dish"] = {}
+    return EDIT_SELECT
+
+
+async def edit_select(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
+    name = update.message.text.strip()
+    dish = await database.get_dish_by_name(name)
+    if not dish:
+        matches = await database.search_dish_names(name, limit=3)
+        if matches:
+            options = ", ".join(match["name"] for match in matches)
+            await update.message.reply_text(f"Не нашёл блюдо. Возможно, вы имели в виду: {options}")
+        else:
+            await update.message.reply_text("Такого блюда нет. Попробуйте снова.")
+        return EDIT_SELECT
+    context.user_data["edit_dish"]["dish"] = dish
+    await update.message.reply_text(
+        "Текущие данные:\n" + format_dish_card(dish)
+    )
+    keyboard_rows = [[label] for label in EDITABLE_FIELDS.keys()]
+    await update.message.reply_text(
+        "Что нужно изменить?",
+        reply_markup=ReplyKeyboardMarkup(keyboard_rows, resize_keyboard=True, one_time_keyboard=True),
+    )
+    return EDIT_FIELD
+
+
+async def edit_field(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
+    choice = update.message.text.strip()
+    field = EDITABLE_FIELDS.get(choice)
+    if field is None and choice != "Готово":
+        await update.message.reply_text("Выберите опцию из списка.")
+        return EDIT_FIELD
+    if field is None:
+        context.user_data.pop("edit_dish", None)
+        await update.message.reply_text("Изменения сохранены.", reply_markup=ReplyKeyboardRemove())
+        return ConversationHandler.END
+    dish = context.user_data["edit_dish"].get("dish")
+    if not dish:
+        await update.message.reply_text("Не удалось найти блюдо. Начните сначала.")
+        return ConversationHandler.END
+    context.user_data["edit_dish"]["field"] = field
+    if field == "is_favorite":
+        new_value = not bool(dish.get("is_favorite"))
+        await database.toggle_favorite(dish["id"], new_value)
+        updated = await database.get_dish_by_id(dish["id"])
+        context.user_data["edit_dish"]["dish"] = updated
+        await update.message.reply_text(
+            "Статус избранного обновлён. Хотите изменить что-то ещё?",
+            reply_markup=ReplyKeyboardMarkup([[label] for label in EDITABLE_FIELDS.keys()], resize_keyboard=True, one_time_keyboard=True),
+        )
+        await database.log_action(str(update.effective_user.id), dish["id"], "favorites_updated", {"name": dish.get("name")})
+        return EDIT_FIELD
+    if field == "category":
+        await update.message.reply_text(
+            "Выберите новую категорию или нажмите 'Пропустить'.",
+            reply_markup=_categories_keyboard(),
+        )
+        return EDIT_VALUE
+    if field == "difficulty":
+        await update.message.reply_text("Выберите сложность или нажмите 'Пропустить'.", reply_markup=_difficulty_keyboard())
+        return EDIT_VALUE
+    if field in {"prep_time", "cook_time"}:
+        await update.message.reply_text("Введите количество минут (целое число).", reply_markup=ReplyKeyboardRemove())
+        return EDIT_VALUE
+    if field == "servings":
+        await update.message.reply_text("Введите новое количество порций.", reply_markup=ReplyKeyboardRemove())
+        return EDIT_VALUE
+    if field == "tags":
+        await update.message.reply_text(
+            "Перечислите теги через запятую.",
+            reply_markup=ReplyKeyboardRemove(),
+        )
+        return EDIT_VALUE
+    await update.message.reply_text("Введите новое значение.", reply_markup=ReplyKeyboardRemove())
+    return EDIT_VALUE
+
+
+async def edit_value(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
+    text = update.message.text.strip()
+    data = context.user_data.get("edit_dish")
+    if not data:
+        await update.message.reply_text("Контекст редактирования утерян. Начните сначала.")
+        return ConversationHandler.END
+    dish = data.get("dish")
+    field = data.get("field")
+    if not dish or not field:
+        await update.message.reply_text("Не удалось обновить блюдо. Попробуйте снова.")
+        return ConversationHandler.END
+    updates: Dict[str, Any] = {}
+    if field == "tags":
+        tags = parse_tags(text)
+        await database.set_dish_tags(dish["id"], tags)
+    else:
+        if field in {"prep_time", "cook_time"}:
+            value = parse_int(text)
+            if value is None or value < 0:
+                await update.message.reply_text("Введите неотрицательное число минут.")
+                return EDIT_VALUE
+            updates[field] = value
+        elif field == "servings":
+            value = parse_float(text)
+            if value is None or value <= 0:
+                await update.message.reply_text("Введите положительное число порций.")
+                return EDIT_VALUE
+            updates[field] = value
+        else:
+            if text == SKIP_KEYWORD:
+                updates[field] = None
+            else:
+                updates[field] = text
+        if updates:
+            await database.update_dish(dish["id"], updates)
+    updated = await database.get_dish_by_id(dish["id"])
+    context.user_data["edit_dish"]["dish"] = updated
+    await update.message.reply_text(
+        "Обновлённая карточка:\n" + format_dish_card(updated),
+    )
+    await database.log_action(str(update.effective_user.id), dish["id"], "dish_updated", {"field": field})
+    keyboard_rows = [[label] for label in EDITABLE_FIELDS.keys()]
+    await update.message.reply_text(
+        "Изменить что-то ещё?",
+        reply_markup=ReplyKeyboardMarkup(keyboard_rows, resize_keyboard=True, one_time_keyboard=True),
+    )
+    return EDIT_FIELD
+
+
+async def delete_dish_entry(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
+    await update.message.reply_text("Введите название блюда, которое нужно удалить.")
+    return DELETE_SELECT
+
+
+async def delete_select(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
+    name = update.message.text.strip()
+    dish = await database.get_dish_by_name(name)
+    if not dish:
+        await update.message.reply_text("Блюдо не найдено. Проверьте название и попробуйте снова.")
+        return DELETE_SELECT
+    context.user_data["delete_dish"] = dish
+    await update.message.reply_text(
+        "Вы собираетесь удалить:\n" + format_dish_card(dish) + "\nВы уверены?",
+        reply_markup=_yes_no_keyboard(),
+    )
+    return DELETE_CONFIRM
+
+
+async def delete_confirm(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
+    answer = update.message.text.strip().lower()
+    dish = context.user_data.pop("delete_dish", None)
+    if answer in NO_ANSWERS or answer == "нет":
+        await update.message.reply_text("Удаление отменено.", reply_markup=ReplyKeyboardRemove())
+        return ConversationHandler.END
+    if not dish:
+        await update.message.reply_text("Не удалось определить блюдо. Попробуйте снова.")
+        return ConversationHandler.END
+    await database.delete_dish(dish["id"])
+    await update.message.reply_text(f"Блюдо '{dish.get('name')}' удалено.", reply_markup=ReplyKeyboardRemove())
+    await database.log_action(str(update.effective_user.id), dish["id"], "dish_deleted", {"name": dish.get("name")})
+    return ConversationHandler.END
+
+
+async def plan_start(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
+    context.user_data["plan"] = {}
+    if update.callback_query:
+        await update.callback_query.answer()
+        await update.callback_query.message.reply_text(
+            "Введите название блюда, которое нужно добавить в план.",
+            reply_markup=ReplyKeyboardRemove(),
+        )
+    else:
+        await update.message.reply_text("Введите название блюда, которое нужно добавить в план.")
+    return PLAN_CHOOSE_DISH
+
+
+async def plan_from_dish_callback(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
+    query = update.callback_query
+    await query.answer()
+    dish_id = int(query.data.split(":", 1)[1])
+    dish = await database.get_dish_by_id(dish_id)
+    if not dish:
+        await query.edit_message_text("Блюдо не найдено. Попробуйте снова через меню.")
+        return ConversationHandler.END
+    context.user_data["plan"] = {"dish": dish}
+    await query.message.reply_text(
+        "Укажите дату (например, 2024-05-20, сегодня или завтра).",
+        reply_markup=ReplyKeyboardRemove(),
+    )
+    return PLAN_SET_DATE
+
+
+async def plan_choose_dish(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
+    name = update.message.text.strip()
+    dish = await database.get_dish_by_name(name)
+    if not dish:
+        matches = await database.search_dish_names(name, limit=3)
+        if matches:
+            suggestions = ", ".join(match["name"] for match in matches)
+            await update.message.reply_text(f"Не нашёл блюдо. Возможно, вы имели в виду: {suggestions}")
+        else:
+            await update.message.reply_text("Блюдо не найдено. Попробуйте снова.")
+        return PLAN_CHOOSE_DISH
+    context.user_data.setdefault("plan", {})["dish"] = dish
+    await update.message.reply_text(
+        "Укажите дату приготовления (например, 2024-05-20, сегодня или завтра).",
+    )
+    return PLAN_SET_DATE
+
+
+async def plan_set_date(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
+    plan_date = parse_date_input(update.message.text)
+    if not plan_date:
+        await update.message.reply_text("Не удалось распознать дату. Используйте формат ГГГГ-ММ-ДД или слова 'сегодня', 'завтра'.")
+        return PLAN_SET_DATE
+    if plan_date < date.today():
+        await update.message.reply_text("Дата не может быть в прошлом.")
+        return PLAN_SET_DATE
+    context.user_data["plan"]["date"] = plan_date.isoformat()
+    await update.message.reply_text("На какой приём пищи поставить блюдо?", reply_markup=_meal_type_keyboard())
+    return PLAN_SET_MEAL
+
+
+async def plan_set_meal(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
+    meal_type = update.message.text.strip()
+    if meal_type not in MEAL_TYPES:
+        await update.message.reply_text("Выберите приём пищи из списка.")
+        return PLAN_SET_MEAL
+    context.user_data["plan"]["meal_type"] = meal_type
+    dish = context.user_data["plan"].get("dish")
+    suggestion = dish.get("servings") if dish else 1
+    await update.message.reply_text(
+        f"Сколько порций приготовить? (по умолчанию {suggestion})",
+        reply_markup=ReplyKeyboardMarkup([[SKIP_KEYWORD]], resize_keyboard=True, one_time_keyboard=True),
+    )
+    return PLAN_SET_SERVINGS
+
+
+async def plan_set_servings(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
+    text = update.message.text.strip()
+    dish = context.user_data["plan"].get("dish")
+    if text == SKIP_KEYWORD:
+        servings = dish.get("servings", 1) if dish else 1
+    else:
+        servings = parse_float(text)
+        if servings is None or servings <= 0:
+            await update.message.reply_text("Введите положительное число или нажмите 'Пропустить'.")
+            return PLAN_SET_SERVINGS
+    context.user_data["plan"]["servings"] = servings
+    await update.message.reply_text(
+        "Добавьте заметку (например, 'приготовить заранее') или нажмите 'Пропустить'.",
+        reply_markup=ReplyKeyboardMarkup([[SKIP_KEYWORD]], resize_keyboard=True, one_time_keyboard=True),
+    )
+    return PLAN_SET_NOTES
+
+
+async def plan_set_notes(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
+    text = update.message.text.strip()
+    if text != SKIP_KEYWORD:
+        context.user_data["plan"]["notes"] = text
+    plan_data = context.user_data.get("plan", {})
+    dish = plan_data.get("dish")
+    if not dish:
+        await update.message.reply_text("Не удалось определить блюдо. Начните сначала.")
+        return ConversationHandler.END
+    plan_id = await database.create_meal_plan(
+        user_id=str(update.effective_user.id),
+        chat_id=update.effective_chat.id,
+        dish_id=dish["id"],
+        plan_date=plan_data["date"],
+        meal_type=plan_data["meal_type"],
+        servings=plan_data.get("servings", dish.get("servings", 1)),
+        notes=plan_data.get("notes"),
+    )
+    context.user_data["plan"]["plan_id"] = plan_id
+    await update.message.reply_text(
+        "Блюдо добавлено в план! Желаете установить напоминание?",
+        reply_markup=_yes_no_keyboard(),
+    )
+    await database.log_action(str(update.effective_user.id), dish["id"], "plan_created", {"plan_id": plan_id})
+    return PLAN_CONFIRM_REMINDER
+
+
+async def plan_confirm_reminder(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
+    answer = update.message.text.strip().lower()
+    if answer in NO_ANSWERS or answer == "нет":
+        context.user_data.pop("plan", None)
+        await update.message.reply_text("Готово! План обновлён.", reply_markup=ReplyKeyboardRemove())
+        return ConversationHandler.END
+    if answer not in YES_ANSWERS and answer != "да":
+        await update.message.reply_text("Ответьте 'Да' или 'Нет'.")
+        return PLAN_CONFIRM_REMINDER
+    await update.message.reply_text(
+        "Укажите время напоминания в формате ЧЧ:ММ.", reply_markup=ReplyKeyboardRemove()
+    )
+    return PLAN_SET_REMINDER_TIME
+
+
+async def plan_set_reminder_time(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
+    plan_data = context.user_data.get("plan")
+    if not plan_data:
+        await update.message.reply_text("Контекст напоминания утерян. Попробуйте снова.")
+        return ConversationHandler.END
+    reminder_time = parse_time_input(update.message.text)
+    if not reminder_time:
+        await update.message.reply_text("Не удалось распознать время. Используйте формат ЧЧ:ММ.")
+        return PLAN_SET_REMINDER_TIME
+    plan_date = datetime.strptime(plan_data["date"], "%Y-%m-%d").date()
+    remind_dt = datetime.combine(plan_date, reminder_time)
+    now = datetime.now()
+    if remind_dt <= now:
+        await update.message.reply_text("Время уже прошло. Укажите более позднее время.")
+        return PLAN_SET_REMINDER_TIME
+    dish = plan_data.get("dish")
+    plan_id = plan_data.get("plan_id")
+    job_name = f"reminder_{plan_id}_{int(remind_dt.timestamp())}"
+    message = (
+        f"⏰ Напоминание: {dish.get('name')} — {plan_data.get('meal_type')} {plan_date.isoformat()}"
+    )
+    job = context.application.job_queue.run_once(
+        callback=send_reminder_job,
+        when=(remind_dt - now),
+        name=job_name,
+        data={
+            "chat_id": update.effective_chat.id,
+            "message": message,
+            "reminder_time": remind_dt.isoformat(),
+            "reminder_id": None,
+            "plan_id": plan_id,
+            "dish_id": dish.get("id"),
+            "user_id": str(update.effective_user.id),
+        },
+    )
+    reminder_id = await database.add_reminder(
+        user_id=str(update.effective_user.id),
+        chat_id=update.effective_chat.id,
+        remind_at=remind_dt.isoformat(),
+        message=message,
+        job_name=job_name,
+        plan_id=plan_id,
+        dish_id=dish.get("id"),
+    )
+    if job and job.data is not None:
+        job.data["reminder_id"] = reminder_id
+    await database.log_action(str(update.effective_user.id), dish.get("id"), "reminder_scheduled", {"reminder_id": reminder_id})
+    await update.message.reply_text("Готово! Напоминание сохранено.")
+    context.user_data.pop("plan", None)
+    return ConversationHandler.END
+
+
+async def send_reminder_job(context: ContextTypes.DEFAULT_TYPE) -> None:
+    job_data = context.job.data or {}
+    message = job_data.get("message", "Напоминание")
+    chat_id = job_data.get("chat_id")
+    reminder_id = job_data.get("reminder_id")
+    if chat_id is None:
+        return
+    await context.bot.send_message(chat_id=chat_id, text=message)
+    if reminder_id:
+        await database.remove_reminder(reminder_id)
+    await database.log_action(job_data.get("user_id", "unknown"), job_data.get("dish_id"), "reminder_sent", {"message": message})
+
+
+async def import_start(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
+    await update.message.reply_text(
+        "Отправьте CSV-файл с блюдами. Формат колонок: "
+        "name,category,cuisine,servings,prep_time,cook_time,difficulty,is_favorite,tags,ingredients,recipe,description,notes.",
+        reply_markup=ReplyKeyboardRemove(),
+    )
+    return IMPORT_WAITING_FILE
+
+
+async def import_receive_file(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
+    document = update.message.document
+    if not document:
+        await update.message.reply_text("Отправьте файл в формате CSV.")
+        return IMPORT_WAITING_FILE
+    filename = (document.file_name or "").lower()
+    if not filename.endswith(".csv"):
+        await update.message.reply_text("Пожалуйста, отправьте файл с расширением .csv.")
+        return IMPORT_WAITING_FILE
+    file = await document.get_file()
+    content = await file.download_as_bytearray()
+    try:
+        text = content.decode("utf-8")
+    except UnicodeDecodeError:
+        text = content.decode("utf-8", errors="ignore")
+    reader = csv.DictReader(io.StringIO(text))
+    result = await database.import_dishes(reader)
+    skipped = ", ".join(result["skipped"]) if result["skipped"] else "нет"
+    await update.message.reply_text(
+        f"Импорт завершён. Добавлено блюд: {result['added']}. Пропущены: {skipped}."
+    )
+    await database.log_action(str(update.effective_user.id), None, "imported", result)
+    return ConversationHandler.END
+
+
+async def find_by_ingredients_start(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
+    await update.message.reply_text(
+        "Введите список доступных ингредиентов через запятую."
+    )
+    return FIND_BY_INGREDIENTS_INPUT
+
+
+async def find_by_ingredients_process(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
+    text = update.message.text.strip()
+    ingredients = [item.strip() for item in text.replace("\n", ",").split(",") if item.strip()]
+    results = await database.get_dish_suggestions_by_ingredients(ingredients)
+    await update.message.reply_text(format_search_results(results), reply_markup=ReplyKeyboardRemove())
+    return ConversationHandler.END
+
+
+async def scale_start(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
+    query = update.callback_query
+    await query.answer()
+    dish_id = int(query.data.split(":", 1)[1])
+    dish = await database.get_dish_by_id(dish_id)
+    if not dish:
+        await query.edit_message_text("Не удалось найти блюдо для масштабирования.")
+        return ConversationHandler.END
+    context.user_data["scale"] = dish
+    await query.message.reply_text(
+        f"На сколько порций нужно приготовить '{dish.get('name')}'? (базово {dish.get('servings', 1)})",
+        reply_markup=ReplyKeyboardRemove(),
+    )
+    return SCALE_WAITING
+
+
+async def scale_receive(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:
+    dish = context.user_data.pop("scale", None)
+    if not dish:
+        await update.message.reply_text("Не удалось определить блюдо.")
+        return ConversationHandler.END
+    servings = parse_float(update.message.text)
+    if servings is None or servings <= 0:
+        context.user_data["scale"] = dish
+        await update.message.reply_text("Введите положительное число порций.")
+        return SCALE_WAITING
+    await update.message.reply_text(format_scaled_ingredients(dish, servings))
+    return ConversationHandler.END
+
+
+add_dish_handler = ConversationHandler(
+    entry_points=[
+        MessageHandler(filters.Regex("^(Добавить блюдо)$"), add_dish_entry),
+        CommandHandler("add_dish", add_dish_entry),
+    ],
     states={
-        ADDING_DISH: [MessageHandler(filters.TEXT & ~filters.COMMAND, save_dish)],
+        ADD_NAME: [MessageHandler(filters.TEXT & ~filters.COMMAND, add_dish_name)],
+        ADD_CATEGORY: [MessageHandler(filters.TEXT & ~filters.COMMAND, add_dish_category)],
+        ADD_CUISINE: [MessageHandler(filters.TEXT & ~filters.COMMAND, add_dish_cuisine)],
+        ADD_SERVINGS: [MessageHandler(filters.TEXT & ~filters.COMMAND, add_dish_servings)],
+        ADD_PREP_TIME: [MessageHandler(filters.TEXT & ~filters.COMMAND, add_dish_prep_time)],
+        ADD_COOK_TIME: [MessageHandler(filters.TEXT & ~filters.COMMAND, add_dish_cook_time)],
+        ADD_DIFFICULTY: [MessageHandler(filters.TEXT & ~filters.COMMAND, add_dish_difficulty)],
+        ADD_DESCRIPTION: [MessageHandler(filters.TEXT & ~filters.COMMAND, add_dish_description)],
+        ADD_INGREDIENTS: [MessageHandler(filters.TEXT & ~filters.COMMAND, add_dish_ingredients)],
+        ADD_INSTRUCTIONS: [MessageHandler(filters.TEXT & ~filters.COMMAND, add_dish_instructions)],
+        ADD_TAGS: [MessageHandler(filters.TEXT & ~filters.COMMAND, add_dish_tags)],
     },
-    fallbacks=[CommandHandler("start", start)]
+    fallbacks=[CommandHandler("cancel", cancel)],
+    allow_reentry=True,
+)
+
+add_details_handler = ConversationHandler(
+    entry_points=[
+        MessageHandler(filters.Regex("^(Добавить детали)$"), add_details_entry),
+        CommandHandler("add_details", add_details_entry),
+    ],
+    states={
+        DETAILS_SELECT: [MessageHandler(filters.TEXT & ~filters.COMMAND, add_details_select)],
+        DETAILS_INGREDIENTS: [MessageHandler(filters.TEXT & ~filters.COMMAND, add_details_ingredients)],
+        DETAILS_INSTRUCTIONS: [MessageHandler(filters.TEXT & ~filters.COMMAND, add_details_instructions)],
+        DETAILS_TAGS: [MessageHandler(filters.TEXT & ~filters.COMMAND, add_details_tags)],
+    },
+    fallbacks=[CommandHandler("cancel", cancel)],
+    allow_reentry=True,
 )
 
 edit_dish_handler = ConversationHandler(
-    entry_points=[MessageHandler(filters.Regex("^(Изменить блюдо)$"), edit_dish)],
+    entry_points=[
+        MessageHandler(filters.Regex("^(Изменить блюдо)$"), edit_dish_entry),
+        CommandHandler("edit_dish", edit_dish_entry),
+    ],
     states={
-        EDITING_DISH: [MessageHandler(filters.TEXT & ~filters.COMMAND, save_edited_dish)],
+        EDIT_SELECT: [MessageHandler(filters.TEXT & ~filters.COMMAND, edit_select)],
+        EDIT_FIELD: [MessageHandler(filters.TEXT & ~filters.COMMAND, edit_field)],
+        EDIT_VALUE: [MessageHandler(filters.TEXT & ~filters.COMMAND, edit_value)],
     },
-    fallbacks=[CommandHandler("start", start)]
+    fallbacks=[CommandHandler("cancel", cancel)],
+    allow_reentry=True,
 )
 
 delete_dish_handler = ConversationHandler(
-    entry_points=[MessageHandler(filters.Regex("^(Удалить блюдо)$"), delete_dish)],
+    entry_points=[
+        MessageHandler(filters.Regex("^(Удалить блюдо)$"), delete_dish_entry),
+        CommandHandler("delete_dish", delete_dish_entry),
+    ],
     states={
-        DELETING_DISH: [MessageHandler(filters.TEXT & ~filters.COMMAND, confirm_delete_dish)],
+        DELETE_SELECT: [MessageHandler(filters.TEXT & ~filters.COMMAND, delete_select)],
+        DELETE_CONFIRM: [MessageHandler(filters.TEXT & ~filters.COMMAND, delete_confirm)],
     },
-    fallbacks=[CommandHandler("start", start)]
+    fallbacks=[CommandHandler("cancel", cancel)],
+    allow_reentry=True,
+)
+
+plan_handler = ConversationHandler(
+    entry_points=[
+        CommandHandler("plan", plan_start),
+        CallbackQueryHandler(plan_start, pattern="^plan_create$"),
+        CallbackQueryHandler(plan_from_dish_callback, pattern="^plan_from_dish:"),
+    ],
+    states={
+        PLAN_CHOOSE_DISH: [MessageHandler(filters.TEXT & ~filters.COMMAND, plan_choose_dish)],
+        PLAN_SET_DATE: [MessageHandler(filters.TEXT & ~filters.COMMAND, plan_set_date)],
+        PLAN_SET_MEAL: [MessageHandler(filters.TEXT & ~filters.COMMAND, plan_set_meal)],
+        PLAN_SET_SERVINGS: [MessageHandler(filters.TEXT & ~filters.COMMAND, plan_set_servings)],
+        PLAN_SET_NOTES: [MessageHandler(filters.TEXT & ~filters.COMMAND, plan_set_notes)],
+        PLAN_CONFIRM_REMINDER: [MessageHandler(filters.TEXT & ~filters.COMMAND, plan_confirm_reminder)],
+        PLAN_SET_REMINDER_TIME: [MessageHandler(filters.TEXT & ~filters.COMMAND, plan_set_reminder_time)],
+    },
+    fallbacks=[CommandHandler("cancel", cancel)],
+    allow_reentry=True,
+)
+
+import_handler = ConversationHandler(
+    entry_points=[
+        CommandHandler("import", import_start),
+        MessageHandler(filters.Regex("^(Импорт)$"), import_start),
+    ],
+    states={
+        IMPORT_WAITING_FILE: [MessageHandler(filters.Document.ALL, import_receive_file)],
+    },
+    fallbacks=[CommandHandler("cancel", cancel)],
+)
+
+find_by_ingredients_handler = ConversationHandler(
+    entry_points=[
+        CommandHandler("find", find_by_ingredients_start),
+        MessageHandler(filters.Regex("^(Поиск по ингредиентам)$"), find_by_ingredients_start),
+    ],
+    states={
+        FIND_BY_INGREDIENTS_INPUT: [MessageHandler(filters.TEXT & ~filters.COMMAND, find_by_ingredients_process)],
+    },
+    fallbacks=[CommandHandler("cancel", cancel)],
+)
+
+scale_dish_handler = ConversationHandler(
+    entry_points=[CallbackQueryHandler(scale_start, pattern="^scale_dish:")],
+    states={
+        SCALE_WAITING: [MessageHandler(filters.TEXT & ~filters.COMMAND, scale_receive)],
+    },
+    fallbacks=[CommandHandler("cancel", cancel)],
 )

--- a/utils.py
+++ b/utils.py
@@ -1,0 +1,397 @@
+from __future__ import annotations
+
+from datetime import date, datetime, time, timedelta
+from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple
+
+MAIN_CATEGORIES = [
+    "Завтрак",
+    "Обед",
+    "Ужин",
+    "Перекус",
+    "Салат",
+    "Десерт",
+    "Напиток",
+    "Суп",
+]
+
+MEAL_TYPES = ["Завтрак", "Обед", "Ужин", "Перекус"]
+DIFFICULTY_LEVELS = ["Легко", "Средне", "Сложно"]
+SKIP_KEYWORD = "Пропустить"
+FINISH_INGREDIENT_KEYWORDS = {"готово", "далее", "хватит", "стоп", "все", "всё"}
+YES_ANSWERS = {"да", "конечно", "ага", "yes", "y"}
+NO_ANSWERS = {"нет", "no", "неа"}
+
+
+def normalize_decimal(text: str) -> str:
+    return text.replace(",", ".").replace(" ", "").strip()
+
+
+def parse_float(value: Any) -> Optional[float]:
+    if value is None:
+        return None
+    text = normalize_decimal(str(value))
+    if not text:
+        return None
+    try:
+        return float(text)
+    except ValueError:
+        return None
+
+
+def parse_int(value: Any) -> Optional[int]:
+    number = parse_float(value)
+    if number is None:
+        return None
+    try:
+        return int(round(number))
+    except (TypeError, ValueError):
+        return None
+
+
+def parse_date_input(text: str) -> Optional[date]:
+    normalized = text.strip().lower()
+    today = date.today()
+    if normalized in {"сегодня", "today"}:
+        return today
+    if normalized in {"завтра", "tomorrow"}:
+        return today + timedelta(days=1)
+    if normalized.startswith("через ") and normalized.endswith(" дней"):
+        number_part = normalized.replace("через", "").replace("дней", "").strip()
+        days = parse_int(number_part)
+        if days is not None:
+            return today + timedelta(days=days)
+    for pattern in ("%Y-%m-%d", "%d.%m.%Y", "%d.%m.%y"):
+        try:
+            return datetime.strptime(normalized, pattern).date()
+        except ValueError:
+            continue
+    return None
+
+
+def parse_time_input(text: str) -> Optional[time]:
+    normalized = text.strip()
+    for pattern in ("%H:%M", "%H.%M", "%H %M"):
+        try:
+            return datetime.strptime(normalized, pattern).time()
+        except ValueError:
+            continue
+    return None
+
+
+def parse_ingredient_input(text: str) -> Dict[str, Any]:
+    parts = [part.strip() for part in text.split(";")]
+    if not parts or not parts[0]:
+        raise ValueError("Название ингредиента обязательно")
+    ingredient: Dict[str, Any] = {"name": parts[0]}
+    if len(parts) > 1 and parts[1]:
+        ingredient["quantity"] = parse_float(parts[1])
+    if len(parts) > 2 and parts[2]:
+        ingredient["unit"] = parts[2]
+    macros_keys = ["calories", "protein", "fat", "carbs"]
+    for index, key in enumerate(macros_keys, start=3):
+        if len(parts) > index and parts[index]:
+            ingredient[key] = parse_float(parts[index])
+    return ingredient
+
+
+def compute_macros(ingredients: Sequence[Dict[str, Any]], ratio: float = 1.0) -> Dict[str, float]:
+    totals = {"calories": 0.0, "protein": 0.0, "fat": 0.0, "carbs": 0.0}
+    for ingredient in ingredients:
+        for key in totals.keys():
+            value = ingredient.get(key)
+            if value is not None:
+                totals[key] += float(value) * ratio
+    return totals
+
+
+def format_macros(macros: Dict[str, float]) -> str:
+    meaningful = {key: value for key, value in macros.items() if value}
+    if not meaningful:
+        return ""
+    parts = []
+    if macros.get("calories"):
+        parts.append(f"Ккал: {round(macros['calories'], 1)}")
+    if macros.get("protein"):
+        parts.append(f"Б: {round(macros['protein'], 1)} г")
+    if macros.get("fat"):
+        parts.append(f"Ж: {round(macros['fat'], 1)} г")
+    if macros.get("carbs"):
+        parts.append(f"У: {round(macros['carbs'], 1)} г")
+    return ", ".join(parts)
+
+
+def humanize_minutes(value: Optional[int]) -> Optional[str]:
+    if not value:
+        return None
+    minutes = int(value)
+    hours, minutes = divmod(minutes, 60)
+    parts = []
+    if hours:
+        parts.append(f"{hours} ч")
+    if minutes:
+        parts.append(f"{minutes} мин")
+    return " ".join(parts) if parts else None
+
+
+def format_duration(prep: Optional[int], cook: Optional[int]) -> Optional[str]:
+    prep_text = humanize_minutes(prep)
+    cook_text = humanize_minutes(cook)
+    if prep_text and cook_text:
+        return f"Подготовка: {prep_text}, готовка: {cook_text}"
+    return prep_text or cook_text
+
+
+def format_ingredients_list(ingredients: Sequence[Dict[str, Any]]) -> str:
+    lines = []
+    for ingredient in ingredients:
+        name = ingredient.get("name")
+        if not name:
+            continue
+        quantity = ingredient.get("quantity")
+        unit = ingredient.get("unit") or ""
+        amount = ""
+        if quantity is not None:
+            number = round(float(quantity), 2)
+            number = int(number) if number.is_integer() else number
+            amount = f" — {number} {unit}".strip()
+        elif unit:
+            amount = f" — {unit}"
+        macros = format_macros({
+            key: ingredient.get(key)
+            for key in ("calories", "protein", "fat", "carbs")
+            if ingredient.get(key) is not None
+        })
+        extra = f" ({macros})" if macros else ""
+        lines.append(f"• {name}{amount}{extra}")
+    return "\n".join(lines)
+
+
+def format_dish_card(dish: Dict[str, Any]) -> str:
+    parts = [f"🍽 {dish.get('name', 'Без названия')}"]
+    meta_lines = []
+    if dish.get("category"):
+        meta_lines.append(f"Категория: {dish['category']}")
+    if dish.get("cuisine"):
+        meta_lines.append(f"Кухня: {dish['cuisine']}")
+    if dish.get("servings"):
+        meta_lines.append(f"Порций: {dish['servings']}")
+    duration = format_duration(dish.get("prep_time"), dish.get("cook_time"))
+    if duration:
+        meta_lines.append(duration)
+    if dish.get("difficulty"):
+        meta_lines.append(f"Сложность: {dish['difficulty']}")
+    if meta_lines:
+        parts.append("\n".join(meta_lines))
+    tags = dish.get("tags") or []
+    if tags:
+        parts.append("Теги: " + ", ".join(sorted(tags)))
+    if dish.get("description"):
+        parts.append(dish["description"])
+    ingredients_text = format_ingredients_list(dish.get("ingredients_list", []))
+    if ingredients_text:
+        parts.append("Ингредиенты:\n" + ingredients_text)
+        macros = compute_macros(dish.get("ingredients_list", []))
+        macros_line = format_macros(macros)
+        if macros_line:
+            parts.append(f"Пищевая ценность на {dish.get('servings', 1)} порц.: {macros_line}")
+    instructions = dish.get("instructions") or dish.get("recipe")
+    if instructions:
+        parts.append("Рецепт:\n" + instructions)
+    if dish.get("notes"):
+        parts.append("Заметки:\n" + dish["notes"])
+    return "\n\n".join(parts)
+
+
+def parse_tags(text: str) -> List[str]:
+    separators = {",", "\n", "#"}
+    for separator in separators:
+        text = text.replace(separator, ",")
+    return [tag.strip() for tag in text.split(",") if tag.strip()]
+
+
+def build_main_keyboard_layout(summary: Dict[str, Any]) -> List[List[str]]:
+    total = summary.get("total_dishes", 0)
+    if not total:
+        return [["Добавить блюдо", "Импорт"], ["Помощь"]]
+    layout = [
+        ["Добавить блюдо", "Меню"],
+        ["Добавить детали", "Изменить блюдо"],
+        ["Удалить блюдо", "Поиск по ингредиентам"],
+        ["План питания", "Список покупок"],
+        ["Избранное", "Статистика"],
+        ["Импорт", "Экспорт"],
+        ["Помощь"],
+    ]
+    return layout
+
+
+def group_plans_by_date(plans: Sequence[Dict[str, Any]]) -> Dict[str, List[Dict[str, Any]]]:
+    grouped: Dict[str, List[Dict[str, Any]]] = {}
+    for plan in plans:
+        grouped.setdefault(plan.get("plan_date"), []).append(plan)
+    for items in grouped.values():
+        items.sort(key=lambda item: MEAL_TYPES.index(item.get("meal_type")) if item.get("meal_type") in MEAL_TYPES else 99)
+    return dict(sorted(grouped.items()))
+
+
+def format_plan_entries(plans: Sequence[Dict[str, Any]]) -> str:
+    if not plans:
+        return "План питания пока пуст. Используйте /plan, чтобы добавить блюда."
+    grouped = group_plans_by_date(plans)
+    lines: List[str] = []
+    for plan_date, entries in grouped.items():
+        lines.append(f"📅 {plan_date}")
+        for entry in entries:
+            servings = entry.get("servings")
+            servings_text = f" × {servings}" if servings else ""
+            note = f" — {entry['notes']}" if entry.get("notes") else ""
+            lines.append(f"  • {entry.get('meal_type', '')}: {entry.get('name', entry.get('dish_name', ''))}{servings_text}{note}")
+    return "\n".join(lines)
+
+
+def format_shopping_items(items: Sequence[Dict[str, Any]]) -> str:
+    if not items:
+        return "Список покупок пуст — запланируйте блюда, чтобы сформировать покупки."
+    lines = ["🛒 Список покупок:"]
+    for item in items:
+        name = item.get("name", "")
+        quantity = item.get("quantity")
+        unit = item.get("unit") or ""
+        amount = ""
+        if quantity is not None:
+            number = round(float(quantity), 2)
+            number = int(number) if number.is_integer() else number
+            amount = f" — {number} {unit}".strip()
+        elif unit:
+            amount = f" — {unit}"
+        macros = format_macros({
+            key: item.get(key)
+            for key in ("calories", "protein", "fat", "carbs")
+            if item.get(key)
+        })
+        extra = f" ({macros})" if macros else ""
+        lines.append(f"• {name}{amount}{extra}")
+    return "\n".join(lines)
+
+
+def format_recent_actions(actions: Sequence[Dict[str, Any]]) -> str:
+    if not actions:
+        return ""
+    mapping = {
+        "dish_added": "добавлено новое блюдо",
+        "dish_updated": "обновлены данные блюда",
+        "dish_deleted": "блюдо удалено",
+        "details_updated": "обновлены ингредиенты",
+        "plan_created": "добавлено в план",
+        "plan_deleted": "удалено из плана",
+        "favorites_updated": "изменён список избранного",
+        "shopping_viewed": "просмотрен список покупок",
+        "statistics_viewed": "просмотрена статистика",
+        "reminder_scheduled": "создано напоминание",
+        "reminder_sent": "отправлено напоминание",
+        "imported": "импортированы блюда",
+    }
+    lines = ["Недавние действия:"]
+    for action in actions:
+        description = mapping.get(action.get("action"), action.get("action"))
+        timestamp = action.get("created_at", "")
+        lines.append(f"• {timestamp}: {description}")
+    return "\n".join(lines)
+
+
+def format_statistics(stats: Dict[str, Any], actions: Sequence[Dict[str, Any]]) -> str:
+    lines = ["📊 Статистика использования"]
+    lines.append(f"Всего блюд в базе: {stats.get('total_dishes', 0)}")
+    lines.append(f"Избранных блюд: {stats.get('favorite_dishes', 0)}")
+    if stats.get("top_categories"):
+        top_categories = ", ".join(
+            f"{row['category']} ({row['count']})" for row in stats["top_categories"]
+        )
+        lines.append("Популярные категории: " + top_categories)
+    if stats.get("top_planned"):
+        top_planned = ", ".join(
+            f"{row['name']} ({row['count']})" for row in stats["top_planned"]
+        )
+        lines.append("Чаще всего в плане: " + top_planned)
+    if stats.get("activity"):
+        lines.append(
+            "Активность: "
+            + ", ".join(f"{key} — {value}" for key, value in stats["activity"].items())
+        )
+    recent = format_recent_actions(actions)
+    if recent:
+        lines.append("\n" + recent)
+    return "\n".join(lines)
+
+
+def scale_ingredients(
+    ingredients: Sequence[Dict[str, Any]],
+    base_servings: float,
+    new_servings: float,
+) -> List[Dict[str, Any]]:
+    if base_servings <= 0:
+        ratio = 1.0
+    else:
+        ratio = new_servings / base_servings
+    scaled: List[Dict[str, Any]] = []
+    for ingredient in ingredients:
+        scaled_item = dict(ingredient)
+        if ingredient.get("quantity") is not None:
+            scaled_item["quantity"] = (ingredient["quantity"] or 0) * ratio
+        for key in ("calories", "protein", "fat", "carbs"):
+            if ingredient.get(key) is not None:
+                scaled_item[key] = (ingredient[key] or 0) * ratio
+        scaled.append(scaled_item)
+    return scaled
+
+
+def format_scaled_ingredients(dish: Dict[str, Any], new_servings: float) -> str:
+    base_servings = float(dish.get("servings") or 1)
+    scaled = scale_ingredients(dish.get("ingredients_list", []), base_servings, new_servings)
+    macros = compute_macros(scaled)
+    lines = [
+        f"Масштабирование рецепта '{dish.get('name')}'",
+        f"Базовое количество порций: {base_servings}",
+        f"Нужно приготовить: {new_servings}",
+        "\nИнгредиенты:",
+        format_ingredients_list(scaled),
+    ]
+    macros_line = format_macros(macros)
+    if macros_line:
+        lines.append(f"\nПищевая ценность для {new_servings} порц.: {macros_line}")
+    return "\n".join(lines)
+
+
+def format_shareable_recipe(dish: Dict[str, Any]) -> str:
+    lines = [f"{dish.get('name', 'Рецепт')}" ]
+    ingredients = format_ingredients_list(dish.get("ingredients_list", []))
+    if ingredients:
+        lines.append("Ингредиенты:\n" + ingredients)
+    instructions = dish.get("instructions") or dish.get("recipe")
+    if instructions:
+        lines.append("\nРецепт:\n" + instructions)
+    return "\n".join(lines)
+
+
+def format_search_results(results: Sequence[Dict[str, Any]]) -> str:
+    if not results:
+        return "Не удалось найти блюда с такими ингредиентами. Попробуйте расширить список." \
+            "\nСначала добавьте блюда через 'Добавить блюдо'."
+    lines = ["Найденные блюда:"]
+    for entry in results[:10]:
+        matched = ", ".join(entry.get("matched", []))
+        missing = ", ".join(entry.get("missing", []))
+        coverage = round(entry.get("coverage", 0) * 100)
+        line = f"• {entry.get('name')} — совпадений {coverage}%"
+        if matched:
+            line += f"\n  Есть: {matched}"
+        if missing:
+            line += f"\n  Не хватает: {missing}"
+        lines.append(line)
+    return "\n".join(lines)
+
+
+def calculate_date_range(days: int = 7) -> Tuple[str, str]:
+    today = date.today()
+    end = today + timedelta(days=days - 1)
+    return today.isoformat(), end.isoformat()


### PR DESCRIPTION
## Summary
- rebuild the sqlite schema with structured ingredients, tags, meal plans, reminders and export helpers
- replace the conversational flows to support detailed dish capture, editing, deletion, planning, importing and ingredient search
- add async handlers for menu browsing, favorites, shopping lists, statistics, exporting and scheduling reminders

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68cd45c0e1e883238c4560bc1dda2496